### PR TITLE
Fixing Ci issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,14 @@ notifications:
     email: false
 addons:
   apt:
+    sources:
+    - ubuntu-toolchain-r-test
     packages:
     - libgmp-dev
+    - g++-4.7
+    
+install:
+    - export CXX=g++-4.7
 script:
     - julia -e 'Pkg.clone(pwd())'
     - julia -e 'Pkg.build("SymEngine")'


### PR DESCRIPTION
getting this error  `GMP library being linked is not supported by CMAKE_CXX_COMPILER `  while running `.travis.yml` on `osx`