### PR TITLE
Pull request/ca0e90ba

### DIFF
--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -6,6 +6,7 @@ export Basic, symbols, @vars
 export free_symbols, get_args
 export ascii_art
 export subs, lambdify, N
+export series
 
 include("../deps/deps.jl")
 

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -5,147 +5,16 @@ import
     Base.convert,
     Base.abs
 
-import Base.Operators: +, -, ^, /, \, *, ==
 
 include("../deps/deps.jl")
 
-type Basic
-    ptr::Ptr{Void}
-    function Basic()
-        z = new(C_NULL)
-        ccall((:basic_new_stack, :libsymengine), Void, (Ptr{Basic}, ), &z)
-        finalizer(z, basic_free)
-        return z
-    end
-end
+include("types.jl")
+include("display.jl")
+include("mathops.jl")
+include("mathfuns.jl")
+include("simplify.jl")
+include("calculus.jl")
 
-basic_free(b::Basic) = ccall((:basic_free_stack, :libsymengine), Void, (Ptr{Basic}, ), &b)
-
-function symbol(s::ASCIIString)
-    a = Basic()
-    ccall((:symbol_set, :libsymengine), Void, (Ptr{Basic}, Ptr{Int8}), &a, s)
-    return a
-end
-
-function toString(b::Basic)
-    a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
-    string = bytestring(a)
-    ccall((:basic_str_free, :libsymengine), Void, (Ptr{Int8}, ), a)
-    return string
-end
-
-function Basic(x::Clong)
-    a = Basic()
-    ccall((:integer_set_si, :libsymengine), Void, (Ptr{Basic}, Clong), &a, x)
-    return a
-end
-
-function Basic(x::Culong)
-    a = Basic()
-    ccall((:integer_set_ui, :libsymengine), Void, (Ptr{Basic}, Culong), &a, x)
-    return a
-end
-
-function Basic(x::BigInt)
-    a = Basic()
-    ccall((:integer_set_mpz, :libsymengine), Void, (Ptr{Basic}, Ptr{BigInt}), &a, &x)
-    return a
-end
-
-if Clong == Int32
-    convert(::Type{Basic}, x::Union{Int8, Int16, Int32}) = Basic(convert(Clong, x))
-    convert(::Type{Basic}, x::Union{UInt8, UInt16, UInt32}) = Basic(convert(Culong, x))
-else
-    convert(::Type{Basic}, x::Union{Int8, Int16, Int32, Int64}) = Basic(convert(Clong, x))
-    convert(::Type{Basic}, x::Union{UInt8, UInt16, UInt32, UInt64}) = Basic(convert(Culong, x))
-end
-convert(::Type{Basic}, x::Integer) = Basic(BigInt(x))
-convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
-
-function +(b1::Basic, b2::Basic)
-    a = Basic()
-    ccall((:basic_add, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    return a
-end
-
-function /(b1::Basic, b2::Basic)
-    a = Basic()
-    ccall((:basic_div, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    return a
-end
-
-function *(b1::Basic, b2::Basic)
-    a = Basic()
-    ccall((:basic_mul, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    return a
-end
-
-function ^(b1::Basic, b2::Basic)
-    a = Basic()
-    ccall((:basic_pow, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    return a
-end
-
-function -(b1::Basic, b2::Basic)
-    a = Basic()
-    ccall((:basic_sub, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    return a
-end
-
-function -(b::Basic)
-    a = Basic()
-    ccall((:basic_neg, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return a
-end
-
-+(b::Basic) = b
-\(b1::Basic, b2::Basic) = b2 / b1
-
-function abs(b::Basic)
-    a = Basic()
-    ccall((:basic_abs, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return a
-end
-
-function ==(b1::Basic, b2::Basic)
-    ccall((:basic_eq, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}), &b1, &b2) == 1
-end
-
-types=Union{Integer, Rational}
-
-+(b1::Basic, b2::types) = b1 + convert(Basic, b2)
-+(b1::types, b2::Basic) = convert(Basic, b1) + b2
--(b1::Basic, b2::types) = b1 - convert(Basic, b2)
--(b1::types, b2::Basic) = convert(Basic, b1) - b2
-*(b1::Basic, b2::types) = b1 * convert(Basic, b2)
-*(b1::types, b2::Basic) = convert(Basic, b1) * b2
-/(b1::Basic, b2::types) = b1 / convert(Basic, b2)
-/(b1::types, b2::Basic) = convert(Basic, b1) / b2
-^(b1::Basic, b2::Integer) = b1 ^ convert(Basic, b2)
-^(b1::Integer, b2::Basic) = convert(Basic, b1) ^ b2
-^(b1::Basic, b2::types) = b1 ^ convert(Basic, b2)
-^(b1::types, b2::Basic) = convert(Basic, b1) ^ b2
-\(b1::Basic, b2::types) = b1 \ convert(Basic, b2)
-\(b1::types, b2::Basic) = convert(Basic, b1) \ b2
-==(b1::Basic, b2::types) = b1 == convert(Basic, b2)
-==(b1::types, b2::Basic) = convert(Basic, b1) == b2
-
-function diff(b1::Basic, b2::Basic)
-    a = Basic()
-    ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    if (ret == 0)
-        error("Second argument must be a symbol.")
-    end
-    return a
-end
-
-function expand(b::Basic)
-    a = Basic()
-    ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return a
-end
-
-show(io::IO, b::Basic) = print(io, toString(b))
 
 end
 

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -9,6 +9,7 @@ import
 include("../deps/deps.jl")
 
 include("types.jl")
+include("subs.jl")
 include("display.jl")
 include("mathops.jl")
 include("mathfuns.jl")

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -1,16 +1,15 @@
 module SymEngine
 
-import
-    Base.show,
-    Base.convert
+import Base: show, convert
 
 include("../deps/deps.jl")
 
+include("ctypes.jl")
 include("types.jl")
-include("subs.jl")
 include("display.jl")
 include("mathops.jl")
 include("mathfuns.jl")
+include("subs.jl")
 include("simplify.jl")
 include("calculus.jl")
 

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -2,6 +2,11 @@ module SymEngine
 
 import Base: show, convert
 
+export Basic, symbols, @vars
+export free_symbols, get_args
+export ascii_art
+export subs, lambdify, N
+
 include("../deps/deps.jl")
 
 include("ctypes.jl")

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -4,7 +4,6 @@ import
     Base.show,
     Base.convert
 
-
 include("../deps/deps.jl")
 
 include("types.jl")

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -2,8 +2,7 @@ module SymEngine
 
 import
     Base.show,
-    Base.convert,
-    Base.abs
+    Base.convert
 
 
 include("../deps/deps.jl")

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -1,0 +1,10 @@
+
+
+function diff(b1::Basic, b2::Basic)
+    a = Basic()
+    ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
+    if (ret == 0)
+        error("Second argument must be a symbol.")
+    end
+    return a
+end

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -2,7 +2,6 @@ import Base: diff
 
 function diff{T<:SymbolicType}(b1::T, b2::BasicType{Val{:Symbol}})
     a = Basic()
-    b1, b2 = map(Basic, (b1, b2))
     ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
     return a
 end

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -7,5 +7,5 @@ function diff{T<:SymbolicType}(b1::T, b2::BasicType{Val{:Symbol}})
     return a
 end
 diff{T<:SymbolicType}(b1::T, b2::BasicType) = throw(ArgumentError("Second argument must be of symbol type"))
-diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S) = diff(b1, _Sym(b2))
+diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S) = diff(b1, BasicType(b2))
 

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -1,10 +1,11 @@
 
 
-function diff(b1::Basic, b2::Basic)
+function diff(b1::BasicType, b2::BasicType)
     a = Basic()
+    b1, b2 = map(Basic, (b1, b2))
     ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
     if (ret == 0)
         error("Second argument must be a symbol.")
     end
-    return a
+    return Sym(a)
 end

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -1,11 +1,11 @@
+import Base: diff
 
-
-function diff(b1::BasicType, b2::BasicType)
+function diff{T<:SymbolicType}(b1::T, b2::BasicType{Val{:Symbol}})
     a = Basic()
     b1, b2 = map(Basic, (b1, b2))
     ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
-    if (ret == 0)
-        error("Second argument must be a symbol.")
-    end
-    return Sym(a)
+    return a
 end
+diff{T<:SymbolicType}(b1::T, b2::BasicType) = throw(ArgumentError("Second argument must be of symbol type"))
+diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S) = diff(b1, _Sym(b2))
+

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -1,10 +1,56 @@
 import Base: diff
 
+
+## diff(ex, x)         f'
+## what is the rest of the interface. This does:
+## diff(ex, x, n)      f^(n)
+## diff(ex, x, y, ...) f_{xy...}  # also diff(ex, (x,y))
+## no support for diff(ex, x,n1, y,n2, ...), but can do diff(ex, (x,y), (n1, n2))
+
 function diff{T<:SymbolicType}(b1::T, b2::BasicType{Val{:Symbol}})
     a = Basic()
     ret = ccall((:basic_diff, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
     return a
 end
+
 diff{T<:SymbolicType}(b1::T, b2::BasicType) = throw(ArgumentError("Second argument must be of symbol type"))
-diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S) = diff(b1, BasicType(b2))
+
+function diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S, n::Integer=1)
+    n < 0 && throw(DomainError("n must be non-negative integer"))
+    n==0 && return b1
+    n==1 && return diff(b1, BasicType(b2))
+    n > 1 && return diff(diff(b1, BasicType(b2)), BasicType(b2), n-1)
+end
+
+function diff(b1::SymbolicType, b2::SymbolicType, b3::SymbolicType)
+    isa(BasicType(b3), BasicType{Val{:Integer}}) ? diff(b1, b2, N(b3)) : diff(b1, (b2, b3))
+end
+
+diff(b1::SymbolicType, b2::SymbolicType, b3::SymbolicType, b4::SymbolicType, b5...) = diff(b1, (b2,b3,b4,b5...))
+    
+## mixed partials
+diff(ex::SymbolicType, bs::Tuple) = reduce((ex, x) -> diff(ex, x), ex, bs)
+diff(ex::SymbolicType, bs::Tuple,ns::Tuple) = reduce((ex, x) -> diff(ex, x[1],x[2]), ex, zip(bs,ns))
+
+
+
+"""
+Series expansion to order `n` about point `x0`
+"""
+function series(ex::SymbolicType, x::SymbolicType, x0=0, n::Union{Integer, Basic}=6)
+    (!isa(N(n), Integer) || n < 0) && throw(DomainError("n must be non-negative integer"))
+
+    fc = subs(ex, x, x0)
+    n==0 && return fc
+
+    fp = ex
+    nfact = Basic(1)
+    for k in 1:n
+        fp = diff(fp, x)
+        nfact = k * nfact
+        fc = fc + subs(fp, x, x0) * (x-x0)^k / nfact
+    end
+
+    fc
+end
 

--- a/src/ctypes.jl
+++ b/src/ctypes.jl
@@ -27,10 +27,11 @@ function Base.getindex(s::CSetBasic, n::UInt)
     result
 end
 
-function Base.convert(::Type{Set}, x::CSetBasic)
+function Base.convert(::Type{Vector}, x::CSetBasic)
     n = Base.length(x)
-    Set([x[i-1] for i in 1:n])
+    [x[i-1] for i in 1:n]
 end
+Base.convert(::Type{Set}, x::CSetBasic) = Set(convert(Vector, x))
 
 ## VecBasic Need this for get_args...
 

--- a/src/ctypes.jl
+++ b/src/ctypes.jl
@@ -1,0 +1,67 @@
+# types from SymEngine to Julia
+
+## XXX BROKEN!! Not sure why XXX
+
+## CSetBasic
+type CSetBasic
+    ptr::Ptr{Void}
+    function CSetBasic(o)
+        z = new(o)
+        ccall((:setbasic_new, :libsymengine), Void, (Ptr{CSetBasic},), &z)
+        finalizer(z, CSetBasic_free)
+        return z
+    end
+    CSetBasic() = CSetBasic(C_NULL)
+end
+
+CSetBasic_free(o::CSetBasic) = ccall((:setbasic_free, :libsymengine), Void, (Ptr{CSetBasic},), &o)
+
+function CSetBasic_size(s::CSetBasic)
+    a = ccall((:setbasic_size,:libsymengine), UInt32, (Ptr{CSetBasic},), &s)
+    convert(Int, a)
+end
+
+function CSetBasic_get(s::CSetBasic, n::Int)
+    result = Basic()
+    ccall((:setbasic_get, :libsymengine), Void, (Ptr{CSetBasic}, Int, Ptr{Basic}), &s, n, &result)
+    result
+end
+
+
+function Base.convert(::Type{Set}, x::CSetBasic)
+    n = CSetBasic_size(x)
+    Set([CSetBasic_get(x, i-1) for i in 1:n])
+end
+
+## VecBasic Need this for get_args...
+
+type CVecBasic
+    ptr::Ptr{Void}  
+    function CVecBasic(o)
+        z = new(o)
+        ccall((:vecbasic_new, :libsymengine), Void, (Ptr{CVecBasic},), &z)
+        finalizer(z, CVecBasic_free)
+        return z
+    end
+    CVecBasic() = CVecBasic(C_NULL)
+end
+
+
+CVecBasic_free(o::CVecBasic) = ccall((:vecbasic_free, :libsymengine), Void, (Ptr{CVecBasic},), &o)
+
+
+function CVecBasic_size(s::CVecBasic)
+    a = ccall((:vecbasic_size, :libsymengine), UInt32, (Ptr{CVecBasic},), &s)
+    convert(Int, a)
+end
+
+function CVecBasic_get(s::CVecBasic, n::Int)
+    result = Basic()
+    ccall((:vecbasic_get, :libsymengine), Void, (Ptr{CVecBasic}, Int, Ptr{Basic}), &s, n, &result)
+    result
+end
+
+function Base.convert(::Type{Vector}, x::CVecBasic)
+    n = CVecBasic_size(x)
+    [CVecBasic_get(x, i-1) for i in 1:n]
+end

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,0 +1,10 @@
+function toString(b::Basic)
+    a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
+    string = bytestring(a)
+    ccall((:basic_str_free, :libsymengine), Void, (Ptr{Int8}, ), a)
+    string = replace(string, "**", "^") # de pythonify
+    return string
+end
+
+
+show(io::IO, b::Basic) = print(io, toString(b))

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,3 +1,4 @@
+
 function toString(b::Basic)
     a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
     string = bytestring(a)
@@ -6,5 +7,7 @@ function toString(b::Basic)
     return string
 end
 
+toString(b::BasicType) = toString(Basic(b))
 
-show(io::IO, b::Basic) = print(io, toString(b))
+
+show(io::IO, b::BasicType) = print(io, toString(b))

--- a/src/display.jl
+++ b/src/display.jl
@@ -8,4 +8,15 @@ function toString(b::SymbolicType)
     return string
 end
 
-show(io::IO, b::SymbolicType) = print(io, toString(b))
+Base.show(io::IO, b::SymbolicType) = print(io, toString(b))
+
+
+" show symengine logo "
+type AsciiArt x end
+function ascii_art()
+    out = ccall((:ascii_art_str, :libsymengine),  Ptr{UInt8},  ())
+    AsciiArt(bytestring(out))
+end
+export ascii_art
+Base.show(io::IO, x::AsciiArt) = print(io, x.x)
+

--- a/src/display.jl
+++ b/src/display.jl
@@ -1,5 +1,6 @@
 
-function toString(b::Basic)
+function toString(b::SymbolicType)
+    b = Basic(b)
     a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
     string = bytestring(a)
     ccall((:basic_str_free, :libsymengine), Void, (Ptr{Int8}, ), a)
@@ -7,7 +8,4 @@ function toString(b::Basic)
     return string
 end
 
-toString(b::BasicType) = toString(Basic(b))
-
-
-show(io::IO, b::BasicType) = print(io, toString(b))
+show(io::IO, b::SymbolicType) = print(io, toString(b))

--- a/src/display.jl
+++ b/src/display.jl
@@ -17,6 +17,6 @@ function ascii_art()
     out = ccall((:ascii_art_str, :libsymengine),  Ptr{UInt8},  ())
     AsciiArt(bytestring(out))
 end
-export ascii_art
+
 Base.show(io::IO, x::AsciiArt) = print(io, x.x)
 

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -36,7 +36,6 @@ for (meth, libnm) in [
     @eval begin
         function ($meth)(b::SymbolicType)
             a = Basic()
-            b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
             return a
         end
@@ -50,7 +49,6 @@ for  (meth, libnm) in [
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
         function ($meth)(b::SymbolicType)
-            a = Basic()
             b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
             return a
@@ -82,7 +80,6 @@ for (meth, libnm) in [(:gcd, :gcd),
     @eval begin
         function ($meth)(a::SymbolicType, b::SymbolicType)
             s = Basic()
-            a,b = map(Basic, (a,b))
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &a, &b)
             return s
         end
@@ -98,7 +95,6 @@ for (meth, libnm) in [(:nextprime,:nextprime)
     @eval begin
         function ($meth)(a::SymbolicType)
             s = Basic()
-            a = Basic(a)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &s, &a)
             return s
         end

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -34,11 +34,11 @@ for (meth, libnm) in [
     eval(Expr(:import, :Base, meth))
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(b::BasicType)
+        function ($meth)(b::SymbolicType)
             a = Basic()
             b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-            return Sym(a)
+            return a
         end
     end
 end
@@ -49,23 +49,23 @@ for  (meth, libnm) in [
                        ]
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(b::BasicType)
+        function ($meth)(b::SymbolicType)
             a = Basic()
             b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-            return Sym(a)
+            return a
         end
     end
     eval(Expr(:export, meth))
 end
 
 ## add
-Base.sqrt(a::BasicType) = a^(1//2)
-Base.cbrt(a::BasicType) = a^(1//3)
+Base.sqrt(a::SymbolicType) = a^(1//2)
+Base.cbrt(a::SymbolicType) = a^(1//3)
 for (meth, fn) in [(:sind, :sin), (:cosd, :cos), (:tand, :tan), (:secd, :sec), (:cscd, :csc), (:cotd, :cot)]
     eval(Expr(:import, :Base, meth))
     @eval begin
-        $(meth)(a::BasicType) = $(fn)(a*PI/180)
+        $(meth)(a::SymbolicType) = $(fn)(a*PI/180)
     end
 end
 
@@ -80,27 +80,27 @@ for (meth, libnm) in [(:gcd, :gcd),
     eval(Expr(:import, :Base, meth))
     tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(a::BasicType, b::BasicType)
+        function ($meth)(a::SymbolicType, b::SymbolicType)
             s = Basic()
-            a,b = map(Basic, (a, b))
+            a,b = map(Basic, (a,b))
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &a, &b)
-            return Sym(s)
+            return s
         end
     end
 end
 
-Base.rem(a::BasicType, b::BasicType) = a - (a ÷ b) * b
+Base.rem(a::SymbolicType, b::SymbolicType) = a - (a ÷ b) * b
 
 ## but not (:fibonacci,:fibonacci), (:lucas, :lucas) (Basic type is not the signature)
 for (meth, libnm) in [(:nextprime,:nextprime)
                       ]
     tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(a::BasicType)
+        function ($meth)(a::SymbolicType)
             s = Basic()
             a = Basic(a)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &s, &a)
-            return Sym(s)
+            return s
         end
     end
     eval(Expr(:export, meth))

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -34,10 +34,11 @@ for (meth, libnm) in [
     eval(Expr(:import, :Base, meth))
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(b::Basic)
+        function ($meth)(b::BasicType)
             a = Basic()
+            b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-            return a
+            return Sym(a)
         end
     end
 end
@@ -48,22 +49,23 @@ for  (meth, libnm) in [
                        ]
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(b::Basic)
+        function ($meth)(b::BasicType)
             a = Basic()
+            b = Basic(b)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-            return a
+            return Sym(a)
         end
     end
     eval(Expr(:export, meth))
 end
 
 ## add
-Base.sqrt(a::Basic) = a^(1//2)
-Base.cbrt(a::Basic) = a^(1//3)
+Base.sqrt(a::BasicType) = a^(1//2)
+Base.cbrt(a::BasicType) = a^(1//3)
 for (meth, fn) in [(:sind, :sin), (:cosd, :cos), (:tand, :tan), (:secd, :sec), (:cscd, :csc), (:cotd, :cot)]
     eval(Expr(:import, :Base, meth))
     @eval begin
-        $(meth)(a::Basic) = $(fn)(a*PI/180)
+        $(meth)(a::BasicType) = $(fn)(a*PI/180)
     end
 end
 
@@ -78,25 +80,27 @@ for (meth, libnm) in [(:gcd, :gcd),
     eval(Expr(:import, :Base, meth))
     tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(a::Basic, b::Basic)
+        function ($meth)(a::BasicType, b::BasicType)
             s = Basic()
+            a,b = map(Basic, (a, b))
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &a, &b)
-            return s
+            return Sym(s)
         end
     end
 end
 
-Base.rem(a::Basic, b::Basic) = a - (a ÷ b) * b
+Base.rem(a::BasicType, b::BasicType) = a - (a ÷ b) * b
 
 ## but not (:fibonacci,:fibonacci), (:lucas, :lucas) (Basic type is not the signature)
 for (meth, libnm) in [(:nextprime,:nextprime)
                       ]
     tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
     @eval begin
-        function ($meth)(a::Basic)
+        function ($meth)(a::BasicType)
             s = Basic()
+            a = Basic(a)
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &s, &a)
-            return s
+            return Sym(s)
         end
     end
     eval(Expr(:export, meth))

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -1,0 +1,104 @@
+
+## these are from cwrapper.cpp, one arg func
+## Where are exp? log?, sqrt?
+for (meth, libnm) in [
+                      (:abs,:abs),
+                      (:sin,:sin),
+                      (:cos,:cos),
+                      (:tan,:tan),
+                      (:csc,:csc),
+                      (:sec,:sec),
+                      (:cot,:cot),
+                      (:asin,:asin),
+                      (:acos,:acos),
+                      (:asec,:asec),
+                      (:acsc,:acsc),
+                      (:atan,:atan),
+                      (:acot,:acot),
+                      (:sinh,:sinh),
+                      (:cosh,:cosh),
+                      (:tanh,:tanh),
+                      (:csch,:csch),
+                      (:sech,:sech),
+                      (:coth,:coth),
+                      (:asinh,:asinh),
+                      (:acosh,:acosh),
+                      (:asech,:asech),
+                      (:acsch,:acsch),
+                      (:atanh,:atanh),
+                      (:acoth,:acoth),
+                      (:zeta,:zeta),
+                      (:gamma,:gamma),
+                      (:eta,:dirichlet_eta),
+                      ]
+    eval(Expr(:import, :Base, meth))
+    tup = (Base.symbol("basic_$libnm"), :libsymengine)
+    @eval begin
+        function ($meth)(b::Basic)
+            a = Basic()
+            ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
+            return a
+        end
+    end
+end
+
+# functions not in 
+for  (meth, libnm) in [
+                       (:lambertw,:lambertw)   # in add-on packages, not base
+                       ]
+    tup = (Base.symbol("basic_$libnm"), :libsymengine)
+    @eval begin
+        function ($meth)(b::Basic)
+            a = Basic()
+            ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
+            return a
+        end
+    end
+    eval(Expr(:export, meth))
+end
+
+## add
+Base.sqrt(a::Basic) = a^(1//2)
+Base.cbrt(a::Basic) = a^(1//3)
+for (meth, fn) in [(:sind, :sin), (:cosd, :cos), (:tand, :tan), (:secd, :sec), (:cscd, :csc), (:cotd, :cot)]
+    eval(Expr(:import, :Base, meth))
+    @eval begin
+        $(meth)(a::Basic) = $(fn)(a*PI/180)
+    end
+end
+
+
+## Number theory module from cppwrapper
+for (meth, libnm) in [(:gcd, :gcd),
+                      (:lcm, :lcm),
+                      (:mod, :mod),
+                      (:div, :quotient),
+                      (:binomial, :binomial)
+                      ]
+    eval(Expr(:import, :Base, meth))
+    tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
+    @eval begin
+        function ($meth)(a::Basic, b::Basic)
+            s = Basic()
+            ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &a, &b)
+            return s
+        end
+    end
+end
+
+Base.rem(a::Basic, b::Basic) = a - (a ÷ b) * b
+
+## but not (:fibonacci,:fibonacci), (:lucas, :lucas) (Basic type is not the signature)
+for (meth, libnm) in [(:nextprime,:nextprime)
+                      ]
+    tup = (Base.symbol("ntheory_$libnm"), :libsymengine)
+    @eval begin
+        function ($meth)(a::Basic)
+            s = Basic()
+            ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}), &s, &a)
+            return s
+        end
+    end
+    eval(Expr(:export, meth))
+    
+end

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -64,9 +64,16 @@ for  (meth, libnm) in [
     eval(Expr(:export, meth))
 end
 
-## add
+## add these in until they are wrapped
+Base.exp(a::SymbolicType) = E^a
+function Base.log(a::SymbolicType) # super hacky
+    u = symbols(gensym())
+    v = a^u
+    diff(v, u) / v
+end
 Base.sqrt(a::SymbolicType) = a^(1//2)
 Base.cbrt(a::SymbolicType) = a^(1//3)
+                  
 for (meth, fn) in [(:sind, :sin), (:cosd, :cos), (:tand, :tan), (:secd, :sec), (:cscd, :csc), (:cotd, :cot)]
     eval(Expr(:import, :Base, meth))
     @eval begin

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -34,10 +34,10 @@ Base.zero{T<:Basic}(::Type{T}) = Basic(0)
 Base.one(x::Basic) = Basic(1)
 Base.one{T<:Basic}(::Type{T}) = Basic(1)
 
-Base.zero(x::BasicType) = _Sym(Basic(0))
-Base.zero{T<:BasicType}(::Type{T}) = _Sym(Basic(0))
-Base.one(x::BasicType) = _Sym(Basic(1))
-Base.one{T<:BasicType}(::Type{T}) = _Sym(Basic(1))
+Base.zero(x::BasicType) = BasicType(Basic(0))
+Base.zero{T<:BasicType}(::Type{T}) = BasicType(Basic(0))
+Base.one(x::BasicType) = BasicType(Basic(1))
+Base.one{T<:BasicType}(::Type{T}) = BasicType(Basic(1))
 
 
 ## Math constants 
@@ -63,5 +63,5 @@ Base.convert(::Type{Basic}, x::Irrational{:π}) = PI
 Base.convert(::Type{Basic}, x::Irrational{:e}) = E
 Base.convert(::Type{Basic}, x::Irrational{:γ}) = EulerGamma
 Base.convert(::Type{Basic}, x::Irrational{:catalan}) = sympy[:Catalan]
-Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Sym(5)^Sym(1//2))/2
-Base.convert(::Type{BasicType}, x::Irrational) = _Sym(convert(Basic, x))
+Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Basic(5)^Basic(1//2))/2
+Base.convert(::Type{BasicType}, x::Irrational) = BasicType(convert(Basic, x))

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -61,6 +61,12 @@ end
 Base.convert(::Type{Basic}, x::Irrational{:π}) = PI
 Base.convert(::Type{Basic}, x::Irrational{:e}) = E
 Base.convert(::Type{Basic}, x::Irrational{:γ}) = EulerGamma
-Base.convert(::Type{Basic}, x::Irrational{:catalan}) = sympy[:Catalan]
+#Base.convert(::Type{Basic}, x::Irrational{:catalan}) = ???
 Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Basic(5)^Basic(1//2))/2
 Base.convert(::Type{BasicType}, x::Irrational) = BasicType(convert(Basic, x))
+
+
+## Logical operators
+Base.(:<)(x::SymbolicType, y::SymbolicType) = N(x) < N(y)
+Base.(:<)(x::SymbolicType, y) = <(promote(x,y)...)
+Base.(:<)(x, y::SymbolicType) = <(promote(x,y)...)

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -1,0 +1,59 @@
+import Base.Operators: +, -, ^, /, \, *, ==
+
+## equality
+function ==(b1::Basic, b2::Basic)
+    ccall((:basic_eq, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}), &b1, &b2) == 1
+end
+
+
+## main ops
+for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (:^, :pow))
+    tup = (Base.symbol("basic_$libnm"), :libsymengine)
+    @eval begin
+        function ($op)(b1::Basic, b2::Basic)
+            a = Basic()
+            ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
+            return a
+        end
+    end
+end
+    
+^{T <: Integer}(a::Basic, b::T) = a^Basic(b)
+^{T <: Rational}(a::Basic, b::T) = a^Basic(b)
++(b::Basic) = b
+-(b::Basic) = 0 - b
+\(b1::Basic, b2::Basic) = b2 / b1
+
+
+## constants
+Base.zero(x::Basic) = Basic(0)
+Base.zero(::Type{Basic}) = Basic(0)
+Base.one(x::Basic) = Basic(1)
+Base.one(::Type{Basic}) = Basic(1)
+
+
+## Math constants 
+## no oo!
+for (op, libnm) in [(:IM, :I),
+                 (:PI, :pi),
+                 (:E, :E),
+                 (:EulerGamma, :EulerGamma)
+                 ]
+    tup = (Base.symbol("basic_const_$libnm"), :libsymengine)
+    @eval begin
+        ($op) = begin
+            a = Basic()
+            ccall($tup, Void, (Ptr{Basic}, ), &a)
+            a
+        end
+    end
+    eval(Expr(:export, op)) 
+end
+    
+## Conversions
+Base.convert(::Type{Basic}, x::Irrational{:π}) = PI
+Base.convert(::Type{Basic}, x::Irrational{:e}) = E
+Base.convert(::Type{Basic}, x::Irrational{:γ}) = EulerGamma
+Base.convert(::Type{Basic}, x::Irrational{:catalan}) = sympy[:Catalan]
+Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Basic(5)^Basic(1//2))/2
+

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -1,4 +1,4 @@
-import Base.Operators: +, -, ^, /, \, *, ==
+import Base.Operators: +, -, ^, /, //, \, *, ==
 
 ## equality
 function ==(b1::BasicType, b2::BasicType)
@@ -8,7 +8,7 @@ end
 
 
 ## main ops
-for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (:^, :pow))
+for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div), (:^, :pow))
     tup = (Base.symbol("basic_$libnm"), :libsymengine)
     @eval begin
         function ($op)(b1::BasicType, b2::BasicType)

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -13,11 +13,10 @@ for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div),
     @eval begin
         function ($op)(b1::Basic, b2::Basic)
             a = Basic()
-            b1, b2 = map(Basic, (b1, b2))
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
             return a
         end
-        ($op){T,S}(b1::BasicType{T},b2::BasicType{S}) = ($op)(Basic(b1),  Basic(b2))
+        ($op)(b1::BasicType, b2::BasicType) = ($op)(Basic(b1), Basic(b2))
     end
 end
 

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -66,6 +66,7 @@ Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Basic(5)^Basic(1//2))/2
 Base.convert(::Type{BasicType}, x::Irrational) = BasicType(convert(Basic, x))
 
 
+
 ## Logical operators
 Base.(:<)(x::SymbolicType, y::SymbolicType) = N(x) < N(y)
 Base.(:<)(x::SymbolicType, y) = <(promote(x,y)...)

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -2,7 +2,7 @@ import Base.Operators: +, -, ^, /, //, \, *, ==
 
 ## equality
 function ==(b1::BasicType, b2::BasicType)
-    b1 = b1.x; b2 = b2.x
+    b1,b2 = map(Basic, (b1, b2))
     ccall((:basic_eq, :libsymengine), Int, (Ptr{Basic}, Ptr{Basic}), &b1, &b2) == 1
 end
 
@@ -13,7 +13,7 @@ for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div),
     @eval begin
         function ($op)(b1::BasicType, b2::BasicType)
             a = Basic()
-            b1,b2 = b1.x, b2.x
+            b1,b2 = map(Basic, (b1, b2))
             ccall($tup, Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &a, &b1, &b2)
             return Sym(a)
         end
@@ -28,10 +28,10 @@ end
 
 
 ## ## constants
-Base.zero(x::BasicType) = BasicInteger(Basic(0))
-Base.zero{T<:BasicType}(::Type{T}) = BasicInteger(Basic(0))
-Base.one(x::Basic) = BasicInteger(Basic(1))
-Base.one{T<:BasicType}(::Type{T}) = BasicInteger(Basic(1))
+Base.zero(x::BasicType) = Sym(Basic(0))
+Base.zero{T<:BasicType}(::Type{T}) = Sym(Basic(0))
+Base.one(x::BasicType) = Sym(Basic(1))
+Base.one{T<:BasicType}(::Type{T}) = Sym(Basic(1))
 
 
 ## Math constants 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,0 +1,6 @@
+
+function expand(b::Basic)
+    a = Basic()
+    ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
+    return a
+end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,8 +1,3 @@
-
-function Base.expand(b::SymbolicType)
-    a = Basic()
-    b = Basic(b)
-    ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return a
-end
+import Base: expand
+IMPLEMENT_ONE_ARG_FUNC(:expand, :expand)
 

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,6 +1,7 @@
 
-function expand(b::Basic)
+function expand(b::BasicType)
     a = Basic()
+    b = Basic(b)
     ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return a
+    return Sym(a)
 end

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,7 +1,8 @@
 
-function Base.expand(b::BasicType)
+function Base.expand(b::SymbolicType)
     a = Basic()
     b = Basic(b)
     ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)
-    return Sym(a)
+    return a
 end
+

--- a/src/simplify.jl
+++ b/src/simplify.jl
@@ -1,5 +1,5 @@
 
-function expand(b::BasicType)
+function Base.expand(b::BasicType)
     a = Basic()
     b = Basic(b)
     ccall((:basic_expand, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}), &a, &b)

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -23,10 +23,8 @@ end
 subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}) = subs(ex, y[1], y[2])
 subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}, args...) = subs(subs(ex, y), args...)
 subs{T <: SymbolicType}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
-export subs
 
-
-## Lamdify
+## Lambdify
 
 ## Mapping of SymEngine Constants into julia values
 constant_map = Dict("pi" => :pi, "E" => :e, "EulerGamma" => :γ)
@@ -61,12 +59,13 @@ function walk_expression(ex)
     Expr(:call, map_fn(fn, fn_map), [walk_expression(a) for a in as]...)
 end
 
+## evaluate symbolless expression or return afunction
 function lambdify(ex::Basic)
     vars = free_symbols(ex)
     if length(vars) == 0
         _lambdify(ex)
     else
-        _lambidfy(ex, vars)
+        _lambdify(ex, vars)
     end
 end
 
@@ -75,9 +74,10 @@ function _lambdify(ex)
     body = walk_expression(ex)
     eval(body)
 end
+
 ## return a function
-function _lambdify(ex::Basic, vars=free_symbols(ex))
-    body = walk_expression(ex, fns=fns, values=values)
+function _lambdify(ex::Basic, vars)
+    body = walk_expression(ex)
 
     try
         eval(Expr(:function,
@@ -100,11 +100,12 @@ N(b::BasicType{Val{:Integer}}) = eval(parse(toString(b)))
 N(b::BasicType{Val{:Rational}}) = eval(parse(replace(toString(b), "/", "//")))
 ## need to test for free_symbols, if none then we need to evaluate
 function N(b::BasicType)
+    b = convert(Basic, b)
     fs = free_symbols(b)
     if length(fs) > 0
         throw(ArgumentError("Object can have no free symbols"))
     end
-    eval(lamdify(b))
+    eval(lambdify(b))
 end
         
 

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -15,13 +15,24 @@ subs(ex, x=>1)  # alternate to subs(x, (x,1))
 subs(ex, x=>1, y=>1) # ditto
 ```
 """
-function subs{T<:BasicType, S<:BasicType}(ex::T, var::S, val)
+function subs{T<:SymbolicType, S<:SymbolicType}(ex::T, var::S, val)
     s = Basic()
     var, val = map(Basic, (var, val))
     ccall((:basic_subs2, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &ex, &var, &val)
-    return Sym(s)
+    return s
 end
-subs{T <: BasicType, S<:BasicType}(ex::T, y::Tuple{S, Any}) = subs(ex, y[1], y[2])
-subs{T <: BasicType, S<:BasicType}(ex::T, y::Tuple{S, Any}, args...) = subs(subs(ex, y), args...)
-subs{T <: BasicType}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
+subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}) = subs(ex, y[1], y[2])
+subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}, args...) = subs(subs(ex, y), args...)
+subs{T <: SymbolicType}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
 export subs
+
+
+# N
+"""
+
+Convert a SymEngine numeric value into a number
+
+"""
+N(b::Basic) = N(_Sym(b))
+N(b::BasicType{Val{:Integer}}) = parse(BigInt, toString(b))
+N(b::BasicType{Val{:Rational}}) = parse(Float64, toString(b))

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -50,6 +50,10 @@ function walk_expression(ex)
         return symbol(toString(ex))
     elseif fn in [:Integer , :Rational]
         return N(ex)
+    elseif fn == :Complex
+        ## hacky
+        x = eval(parse(replace(toString(ex), "I", "im")))
+        return Expr(:call, :complex, real(x), imag(x))
     elseif fn == :Constant
         return constant_map(toString(ex))
     end
@@ -96,8 +100,13 @@ Convert a SymEngine numeric value into a number
 
 """
 N(b::Basic) = N(BasicType(b))
-N(b::BasicType{Val{:Integer}}) = eval(parse(toString(b)))
+N(b::BasicType{Val{:Integer}}) = eval(parse(toString(b)))  ## HACKY
 N(b::BasicType{Val{:Rational}}) = eval(parse(replace(toString(b), "/", "//")))
+N(b::BasicType{Val{:Complex}}) =  eval(parse(replace(toString(b), "I", "im")))
+
+## function N(b::BasicType{Val{:Rational}})
+##     println("XXX")
+## end
 ## need to test for free_symbols, if none then we need to evaluate
 function N(b::BasicType)
     b = convert(Basic, b)
@@ -111,3 +120,4 @@ end
 
 N(a::Integer) = a
 N(a::Rational) = a
+N(a::Complex) = a

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -17,7 +17,6 @@ subs(ex, x=>1, y=>1) # ditto
 """
 function subs{T<:SymbolicType, S<:SymbolicType}(ex::T, var::S, val)
     s = Basic()
-    var, val = map(Basic, (var, val))
     ccall((:basic_subs2, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &ex, &var, &val)
     return s
 end
@@ -25,6 +24,69 @@ subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}) = subs(ex, y[1
 subs{T <: SymbolicType, S<:SymbolicType}(ex::T, y::Tuple{S, Any}, args...) = subs(subs(ex, y), args...)
 subs{T <: SymbolicType}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
 export subs
+
+
+## Lamdify
+
+## Mapping of SymEngine Constants into julia values
+constant_map = Dict("pi" => :pi, "E" => :e, "EulerGamma" => :γ)
+
+## Map symengine classes to function names
+fn_map = Dict(
+              :Add => :+,
+              :Sub => :-,
+              :Mul => :*,
+              :Div => :/,
+              :Pow => :^,
+              :re  => :real,
+              :im  => :imag,
+              :Abs => :abs # not really needed as default in map_fn covers this
+              )
+
+map_fn(key, fn_map) = haskey(fn_map, key) ? fn_map[key] : symbol(lowercase(string(key)))
+
+function walk_expression(ex)
+    fn = get_symengine_class(ex)
+    
+    if fn == :Symbol
+        return symbol(toString(ex))
+    elseif fn in [:Integer , :Rational]
+        return N(ex)
+    elseif fn == :Constant
+        return constant_map(toString(ex))
+    end
+
+    as = get_args(ex)
+
+    Expr(:call, map_fn(fn, fn_map), [walk_expression(a) for a in as]...)
+end
+
+function lambdify(ex::Basic)
+    vars = free_symbols(ex)
+    if length(vars) == 0
+        _lambdify(ex)
+    else
+        _lambidfy(ex, vars)
+    end
+end
+
+## return a number
+function _lambdify(ex)
+    body = walk_expression(ex)
+    eval(body)
+end
+## return a function
+function _lambdify(ex::Basic, vars=free_symbols(ex))
+    body = walk_expression(ex, fns=fns, values=values)
+
+    try
+        eval(Expr(:function,
+                  Expr(:call, gensym(), map(symbol,vars)...),
+                  body))
+    catch err
+        throw(ArgumentError("Expression does not lambdify"))
+    end
+end
 
 
 # N
@@ -36,3 +98,15 @@ Convert a SymEngine numeric value into a number
 N(b::Basic) = N(BasicType(b))
 N(b::BasicType{Val{:Integer}}) = eval(parse(toString(b)))
 N(b::BasicType{Val{:Rational}}) = eval(parse(replace(toString(b), "/", "//")))
+## need to test for free_symbols, if none then we need to evaluate
+function N(b::BasicType)
+    fs = free_symbols(b)
+    if length(fs) > 0
+        throw(ArgumentError("Object can have no free symbols"))
+    end
+    eval(lamdify(b))
+end
+        
+
+N(a::Integer) = a
+N(a::Rational) = a

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -1,0 +1,27 @@
+
+
+## subs
+"""
+Substitute values into a symbolic expression.
+
+Examples
+```
+@syms x y
+ex = x^2 + y^2
+subs(ex, x, 1) # 1 + y^2
+subs(ex, (x, 1)) # 1 + y^2
+subs(ex, (x, 1), (y,x)) # 1 + x^2, values are substituted left to right.
+subs(ex, x=>1)  # alternate to subs(x, (x,1))
+subs(ex, x=>1, y=>1) # ditto
+```
+"""
+function subs{T<:BasicType, S<:BasicType}(ex::T, var::S, val)
+    s = Basic()
+    var, val = map(Basic, (var, val))
+    ccall((:basic_subs2, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &ex, &var, &val)
+    return Sym(s)
+end
+subs{T <: BasicType, S<:BasicType}(ex::T, y::Tuple{S, Any}) = subs(ex, y[1], y[2])
+subs{T <: BasicType, S<:BasicType}(ex::T, y::Tuple{S, Any}, args...) = subs(subs(ex, y), args...)
+subs{T <: BasicType}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
+export subs

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -33,6 +33,6 @@ export subs
 Convert a SymEngine numeric value into a number
 
 """
-N(b::Basic) = N(_Sym(b))
-N(b::BasicType{Val{:Integer}}) = parse(BigInt, toString(b))
-N(b::BasicType{Val{:Rational}}) = parse(Float64, toString(b))
+N(b::Basic) = N(BasicType(b))
+N(b::BasicType{Val{:Integer}}) = eval(parse(toString(b)))
+N(b::BasicType{Val{:Rational}}) = eval(parse(replace(toString(b), "/", "//")))

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,7 @@ export Basic
 basic_free(b::Basic) = ccall((:basic_free_stack, :libsymengine), Void, (Ptr{Basic}, ), &b)
 
 
+
 function Basic(x::Clong)
     a = Basic()
     ccall((:integer_set_si, :libsymengine), Void, (Ptr{Basic}, Clong), &a, x)
@@ -57,9 +58,28 @@ convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
 
 Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic
 
+## Class ID
+get_type(s::Basic) = convert(Int, ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s))
+get_class_from_id(id::Int) = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (Int,), id) |> bytestring
+"Get SymEngine class of an object (e.g. 1=>:Integer, 1//2 =:Rational, sin(x) => :Sin, ..."
+get_symengine_class(s::Basic) = symbol(get_class_from_id(get_type(s)))
+
+" Return free symbols in an expression as a `Set`"
+function free_symbols(ex::Basic)
+    syms = CSetBasic()
+    ccall((:basic_free_symbols, :libsymengine), Void, (Ptr{Basic}, Ptr{SymEngine.CSetBasic}), &ex, &syms)
+    convert(Set, syms)
+end
+
+"Return arguments of a function call as a vector of `Basic` objects"
+function get_args(ex::Basic)
+    args = CVecBasic()
+    ccall((:basic_get_args, :libsymengine), Void, (Ptr{Basic}, Ptr{CVecBasic}), &ex, &args)
+    convert(Vector, args)
+end
 
 ## Construct symbolic objects
-## rename? This conflicts with Base.symbol
+## renamed, as `symbol` conflicts with Base.symbol
 function _symbol(s::ASCIIString)
     a = Basic()
     ccall((:symbol_set, :libsymengine), Void, (Ptr{Basic}, Ptr{Int8}), &a, s)
@@ -67,9 +87,28 @@ function _symbol(s::ASCIIString)
 end
 _symbol(s::Symbol) = _symbol(string(s))
 
-"`symbols(::Symbol)` construct symbolic value"
+## use SymPy name here, but no assumptions
+"""
+
+`symbols(::Symbol)` construct symbolic value
+
+Examples:
+```
+a = symbols(:a)
+x = symbols("x")
+x,y = symbols("x y")
+x,y,z = symbols("x,y,z")
+```
+
+"""
 symbols(s::Symbol) = _symbol(s)
-symbols(s::ASCIIString) = [_symbol(symbol(o)) for o in split(replace(s, ",", " "), r"\s+")]
+function symbols(s::ASCIIString)
+    ## handle space or comma sparation
+    s = replace(s, ",", " ")
+    by_space = split(s, r"\s+")
+    length(by_space) == 1 && return symbols(symbol(s))
+    tuple([_symbol(symbol(o)) for o in by_space]...)
+end
 export symbols
 
 
@@ -109,12 +148,9 @@ export @vars
 ## cons: have to write methods meth(x::Basic, ...) = meth(BasicType(x),...)
 
 
-## Wrapper type
-## this allows SymEngine.jl to keep track of the class of the C++ object
 
 
-
-## Parameterized type allowing or dispatch on Julia side by type of objecton SymEngine side
+## Parameterized type allowing for dispatch on Julia side by type of objecton SymEngine side
 ## Use as BasicType{Val{:Integer}}(...)
 ## To take advantage of this, define
 ## meth(x::Basic) = meth(BasicType(x))
@@ -129,27 +165,8 @@ SymbolicType = Union{Basic, BasicType}
 convert(::Type{Basic}, x::BasicType) = x.x
 Basic(x::BasicType) = x.x
 
-function get_type(s::Basic)
-    id = ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
-    convert(Int, id)
-end
-
-function get_class_from_id(id::Int)
-    out = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (Int,), id)
-    bytestring(out)
-end
-
-"
-Get SymEngine class of an object (e.g. 1=>:Integer, 1//2 =:Rational, sin(x) => :Sin, ...
-"
-get_symengine_class(s::Basic) = symbol(get_class_from_id(get_type(s)))
-
-## Convert a Basic value into one of the BasicType values
-function Base.convert(::Type{BasicType}, val::Basic)
-    nm = get_symengine_class(val)
-    BasicType{Val{nm}}(val)
-end
-Base.convert{T}(::Type{BasicType{T}}, val::Basic) = convert(BasicType, val)
+BasicType(val::Basic) =  BasicType{Val{get_symengine_class(val)}}(val)
+Base.convert{T}(::Type{BasicType{T}}, val::Basic) = BasicType{Val{get_symengine_class(val)}}(val)
 
 
 
@@ -163,14 +180,11 @@ Base.promote_rule{T<:BasicType, S<:Number}(::Type{T}, ::Type{S} ) = T
 Base.promote_rule{T<:BasicType}(::Type{T}, ::Type{Basic} ) = T
 Base.promote_rule{T<:BasicType}( ::Type{Basic}, ::Type{T} ) = T
 
-# is this not needed?
-#Base.convert{T<:BasicType}(::Type{Basic}, val::T) = val.x
-
 ## needed for mathops
 Base.convert{T<:BasicType}(::Type{T}, val::Number) = T(Basic(val))
 
 
-## some type unions used for dispatch
+## some type unions possibly useful for dispatch
 ## Names here match those returned by get_symengine_class()
 number_types = [:Integer, :Rational, :Complex]
 BasicNumber = Union{[SymEngine.BasicType{Val{i}} for i in number_types]...}

--- a/src/types.jl
+++ b/src/types.jl
@@ -64,19 +64,9 @@ const SYMENGINE_ENUM = Dict{Int, Symbol}(0 => :Integer,
                                          16 => :Pow,
                                          19 => :Constant)
 
+## a dictionary to hold our dynamically generated subtypes of BasicType
 _basic_types = Dict()
 
-## for (k,v) in SYMENGINE_ENUM
-##     tname = symbol("Basic$v")
-##     fname = symbol("basic_free_$v")
-##     @eval begin
-##         type $tname <: BasicType
-##             x::Basic
-##         end
-##         _basic_types[$k] = $tname
-##     end
-## end
-##
 type BasicValue <: BasicType
     x::Basic
 end
@@ -92,6 +82,9 @@ function get_class_id(id)
     ccall((:basic_get_class_id, :libsymengine), AbstractString, (Ptr{AbstractString},), &s)
 end
 
+## Convert a Basic value inton one of the BasicType values
+## These types are generated dynamically using an id and typename gathered from the Basic object
+## XXX this needs hooking up with get_class_id XXX
 function Base.convert(::Type{BasicType}, val::Basic)
     id = get_type(val)
     if !haskey(_basic_types, id)

--- a/src/types.jl
+++ b/src/types.jl
@@ -67,15 +67,15 @@ function _symbol(s::ASCIIString)
 end
 _symbol(s::Symbol) = _symbol(string(s))
 
-"""
+"`symbols(::Symbol)` construct symbolic value"
+symbols(s::Symbol) = _symbol(s)
+symbols(s::ASCIIString) = [_symbol(symbol(o)) for o in split(replace(s, ",", " "), r"\s+")]
+export symbols
 
-Convenience for construction of symbolic values
 
-"""
-Sym(s::ASCIIString) = _symbol(s)
-Sym(s::Symbol) = Sym(string(s))
-Sym(s::Any) = Basic(s)
-export Sym
+
+
+## Follow, somewhat, the python names: symbols to construct symbols, @vars
 
 
 """
@@ -85,10 +85,10 @@ Symbolic values are defined with `_symbol`. This is a convenience
 
 Example
 ```
-@syms x y z
+@vars x y z
 ```
 """
-macro syms(x...)
+macro vars(x...)
     q=Expr(:block)
     if length(x) == 1 && isa(x[1],Expr)
         @assert x[1].head === :tuple "@syms expected a list of symbols"
@@ -101,7 +101,7 @@ macro syms(x...)
     push!(q.args, Expr(:tuple, x...))
     eval(Main, q)
 end
-export @syms
+export @vars
 
 
 ## We also have a wrapper type that can be used to control dispatch

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,0 +1,110 @@
+
+abstract SymbolicNumber <: Number
+
+type Basic <: SymbolicNumber
+    ptr::Ptr{Void}
+    function Basic()
+        z = new(C_NULL)
+        ccall((:basic_new_stack, :libsymengine), Void, (Ptr{Basic}, ), &z)
+        finalizer(z, basic_free)
+        return z
+    end
+end
+export Basic
+
+Base.promote_rule{T<:SymbolicNumber, S<:Number}(::Type{T}, ::Type{S} ) = T
+
+basic_free(b::Basic) = ccall((:basic_free_stack, :libsymengine), Void, (Ptr{Basic}, ), &b)
+
+
+function Basic(x::Clong)
+    a = Basic()
+    ccall((:integer_set_si, :libsymengine), Void, (Ptr{Basic}, Clong), &a, x)
+    return a
+end
+
+function Basic(x::Culong)
+    a = Basic()
+    ccall((:integer_set_ui, :libsymengine), Void, (Ptr{Basic}, Culong), &a, x)
+    return a
+end
+
+function Basic(x::BigInt)
+    a = Basic()
+    ccall((:integer_set_mpz, :libsymengine), Void, (Ptr{Basic}, Ptr{BigInt}), &a, &x)
+    return a
+end
+
+
+if Clong == Int32
+    convert(::Type{Basic}, x::Union{Int8, Int16, Int32}) = Basic(convert(Clong, x))
+    convert(::Type{Basic}, x::Union{UInt8, UInt16, UInt32}) = Basic(convert(Culong, x))
+else
+    convert(::Type{Basic}, x::Union{Int8, Int16, Int32, Int64}) = Basic(convert(Clong, x))
+    convert(::Type{Basic}, x::Union{UInt8, UInt16, UInt32, UInt64}) = Basic(convert(Culong, x))
+end
+convert(::Type{Basic}, x::Integer) = Basic(BigInt(x))
+convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
+
+
+## Construct symbolic objects
+## rename? This conflicts with Base.symbol
+function _symbol(s::ASCIIString)
+    a = Basic()
+    ccall((:symbol_set, :libsymengine), Void, (Ptr{Basic}, Ptr{Int8}), &a, s)
+    return a
+end
+_symbol(s::Symbol) = _symbol(string(s))
+
+"""
+
+Macro to define 1 or more variables in the main workspace.
+
+Symbolic values are defined with `_symbol`. This is a convenience
+
+Example
+```
+@syms x y z
+```
+"""
+macro syms(x...)
+    q=Expr(:block)
+    if length(x) == 1 && isa(x[1],Expr)
+        @assert x[1].head === :tuple "@syms expected a list of symbols"
+        x = x[1].args
+    end
+    for s in x
+        @assert isa(s,Symbol) "@syms expected a list of symbols"
+        push!(q.args, Expr(:(=), s, Expr(:call, :(SymEngine._symbol), Expr(:quote, s))))
+    end
+    push!(q.args, Expr(:tuple, x...))
+    eval(Main, q)
+end
+export @syms
+
+
+## subs
+"""
+Substitute values into a symbolic expression.
+
+Examples
+```
+@syms x y
+ex = x^2 + y^2
+subs(ex, x, 1) # 1 + y^2
+subs(ex, (x, 1)) # 1 + y^2
+subs(ex, (x, 1), (y,x)) # 1 + x^2, values are substituted left to right.
+subs(ex, x=>1)  # alternate to subs(x, (x,1))
+subs(ex, x=>1, y=>1) # ditto
+```
+"""
+function subs(ex::Basic, var::Basic, val)
+    s = Basic()
+    val = Basic(val)
+    ccall((:basic_subs2, :libsymengine), Void, (Ptr{Basic}, Ptr{Basic}, Ptr{Basic}, Ptr{Basic}), &s, &ex, &var, &val)
+    return s
+end
+subs{T <: Basic}(ex::T, y::Tuple{Basic, Any}) = subs(ex, y[1], y[2])
+subs{T <: Basic}(ex::T, y::Tuple{Basic, Any}, args...) = subs(subs(ex, y), args...)
+subs{T <: Basic}(ex::T, d::Pair...) = subs(ex, [(p.first, p.second) for p in d]...)
+export subs

--- a/src/types.jl
+++ b/src/types.jl
@@ -74,12 +74,12 @@ end
 Basic(x::BasicType) = x.x
 
 function get_type(s::Basic)
-    ccall((:basic_get_type, :libsymengine), Int, (Ptr{Basic},), &s)
+    ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
 end
 
 function get_class_id(id)
     id = string(id)
-    ccall((:basic_get_class_id, :libsymengine), AbstractString, (Ptr{AbstractString},), &s)
+    ccall((:basic_get_class_id, :libsymengine), AbstractString, (Ptr{AbstractString},), &id)
 end
 
 ## Convert a Basic value into one of the BasicType values
@@ -90,6 +90,18 @@ function Base.convert(::Type{BasicType}, val::Basic)
     nm = haskey(SYMENGINE_ENUM, id) ? SYMENGINE_ENUM[id] : :Value  # work around until get_class_id is exposed
     BasicType{Val{nm}}(val)
 end
+
+## some type unions used for dispatch
+number_types = [:Integer, :Rational, :Complex]
+BasicNumber = Union{[SymEngine.BasicType{Val{i}} for i in number_types]...}
+
+op_types = [:Mul, :Add, :Pow, :Symbol, :Const]
+BasicOp = Union{[SymEngine.BasicType{Val{i}} for i in op_types]...}
+
+trig_types = [:Sin, :Cos, :Tan, :Csc, :Sec, :Cot, :ASin, :ACos, :ATan, :ACsc, :ASec, :ACot]
+BasicTrigFunction =  Union{[SymEngine.BasicType{Val{i}} for i in trig_types]...}
+
+
 
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -1,6 +1,12 @@
+## We have different types:
+## Basic: holds a ptr to a symengine object. Faster, so is default type
+## BasicType{Val{:XXX}}: types that can be use to control dispatch
+## SymbolicType: a type union of the two
+## Basic(x::BasicType) gives a basic object; _Sym(x::Basic) gives a BasicType object. (This name needs change)
+## To control dispatch, one might have `N(b::Basic) = N(_Sym(b))` and then define `N` for types of interest
 
 ## Hold a reference to a SymEngine object
-type Basic 
+type Basic  <: Number
     ptr::Ptr{Void}
     function Basic()
         z = new(C_NULL)
@@ -42,80 +48,7 @@ else
     convert(::Type{Basic}, x::Union{UInt8, UInt16, UInt32, UInt64}) = Basic(convert(Culong, x))
 end
 convert(::Type{Basic}, x::Integer) = Basic(BigInt(x))
-convert(::Type{Basic}, x::Rational) = Basic(BasicType{Val{:Integer}}(num(x)) / BasicType{Val{:Integer}}(den(x)))
-
-
-
-## Wrapper type
-## this allows SymEngine.jl to keep track of the class of the C++ object
-## XXX This needs to be generated from symengine on startup
-## XXX This might be tedious with precompilation!
-const SYMENGINE_ENUM = Dict{Int, Symbol}(0 => :Integer,
-                                         1 => :Rational,
-                                         2 => :Complex,
-                                         3 => :ComplexDouble,
-                                         11 => :Symbol,
-                                         12 => :EmptySet,
-                                         13 => :Interval,
-                                         14 => :Mul,
-                                         15 => :Add,
-                                         16 => :Pow,
-                                         19 => :Constant,
-                                         20 => :Sin,
-                                         21 => :Cos
-                                         )
-
-## Parameterized type allowing or dispatch on Julia side by type of objecton SymEngine side
-## Use as BasicType{Val{:Integer}}(...)
-type BasicType{T} <: Number
-    x::Basic
-end
-
-Basic(x::BasicType) = x.x
-
-function get_type(s::Basic)
-    ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
-end
-
-function get_class_id(id)
-    id = string(id)
-    ccall((:basic_get_class_id, :libsymengine), AbstractString, (Ptr{AbstractString},), &id)
-end
-
-## Convert a Basic value into one of the BasicType values
-## XXX this needs hooking up with get_class_id XXX
-function Base.convert(::Type{BasicType}, val::Basic)
-    id = get_type(val)
-    # nm = get_class_id(id)
-    nm = haskey(SYMENGINE_ENUM, id) ? SYMENGINE_ENUM[id] : :Value  # work around until get_class_id is exposed
-    BasicType{Val{nm}}(val)
-end
-
-## some type unions used for dispatch
-number_types = [:Integer, :Rational, :Complex]
-BasicNumber = Union{[SymEngine.BasicType{Val{i}} for i in number_types]...}
-
-op_types = [:Mul, :Add, :Pow, :Symbol, :Const]
-BasicOp = Union{[SymEngine.BasicType{Val{i}} for i in op_types]...}
-
-trig_types = [:Sin, :Cos, :Tan, :Csc, :Sec, :Cot, :ASin, :ACos, :ATan, :ACsc, :ASec, :ACot]
-BasicTrigFunction =  Union{[SymEngine.BasicType{Val{i}} for i in trig_types]...}
-
-
-
-
-
-Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = T
-Base.promote_rule{T<:BasicType, S<:Number}(::Type{T}, ::Type{S} ) = T
-
-Base.convert{T<:BasicType}(::Type{Basic}, val::T) = val.x
-Base.convert{T<:BasicType}(::Type{T}, val::Integer) = T(Basic(val))
-Base.convert{T<:BasicType}(::Type{T}, val::Rational) = T(Basic(val))
-
-
-
-
-
+convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
 
 
 
@@ -124,12 +57,22 @@ Base.convert{T<:BasicType}(::Type{T}, val::Rational) = T(Basic(val))
 function _symbol(s::ASCIIString)
     a = Basic()
     ccall((:symbol_set, :libsymengine), Void, (Ptr{Basic}, Ptr{Int8}), &a, s)
-    return BasicType{Val{:Symbol}}(a)
+    return a
 end
 _symbol(s::Symbol) = _symbol(string(s))
 
 """
 
+Convenience for construction symbolic values
+
+"""
+Sym(s::ASCIIString) = _symbol(s)
+Sym(s::Symbol) = Sym(string(s))
+Sym(s::Any) = Basic(s)
+export Sym
+
+
+"""
 Macro to define 1 or more variables in the main workspace.
 
 Symbolic values are defined with `_symbol`. This is a convenience
@@ -155,17 +98,96 @@ end
 export @syms
 
 
-## We have a bit of a mess with Basic and BasicType
-## Basic is not what we want to use externally. Create a Sym function for that
-"""
+## We also have a wrapper type that can be used to control dispatch
+## pros: wrapping adds overhead, so if possible best to use Basic
+## cons: have to write methods meth(x::Basic, ...) = meth(Sym(x),...)
 
-Create a symbolic object
 
-"""
-Sym(x::AbstractString) = _symbol(x)
-Sym(x::Symbol) = _symbol(x)
-Sym(x::Any) = convert(BasicType, Basic(x))
-export Sym
+## Wrapper type
+## this allows SymEngine.jl to keep track of the class of the C++ object
+
+
+## XXX Temporarary, to be replaced by get_class_from_id
+const SYMENGINE_ENUM = Dict{Int, Symbol}(0 => :Integer,
+                                         1 => :Rational,
+                                         2 => :Complex,
+                                         3 => :ComplexDouble,
+                                         11 => :Symbol,
+                                         12 => :EmptySet,
+                                         13 => :Interval,
+                                         14 => :Mul,
+                                         15 => :Add,
+                                         16 => :Pow,
+                                         19 => :Constant,
+                                         20 => :Sin,
+                                         21 => :Cos
+                                         )
+
+## Parameterized type allowing or dispatch on Julia side by type of objecton SymEngine side
+## Use as BasicType{Val{:Integer}}(...)
+## To take advantage of this, define
+## meth(x::Basic) = meth(_Sym(x))
+## and then
+## meth(x::BasicType{Val{:Integer}}) = ... or
+## meth(x::BasicNumber) = ...
+type BasicType{T} <: Number
+    x::Basic
+end
+
+SymbolicType = Union{Basic, BasicType}
+
+Basic(x::BasicType) = x.x
+
+function get_type(s::Basic)
+    ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
+end
+
+function get_class_from_id(id)
+    id = string(id)
+    ccall((:basic_get_class_from_id, :libsymengine), AbstractString, (Ptr{AbstractString},), &id)
+end
+
+## Convert a Basic value into one of the BasicType values
+## XXX this needs hooking up with get_class_from_id XXX
+function Base.convert(::Type{BasicType}, val::Basic)
+    id = get_type(val)
+    # nm = get_class_from_id(id)
+    nm = haskey(SYMENGINE_ENUM, id) ? SYMENGINE_ENUM[id] : :Value  # work around until get_class_id is exposed
+    BasicType{Val{nm}}(val)
+end
+Base.convert{T}(::Type{BasicType{T}}, val::Basic) = convert(BasicType, val)
+
+## some type unions used for dispatch
+number_types = [:Integer, :Rational, :Complex]
+BasicNumber = Union{[SymEngine.BasicType{Val{i}} for i in number_types]...}
+
+op_types = [:Mul, :Add, :Pow, :Symbol, :Const]
+BasicOp = Union{[SymEngine.BasicType{Val{i}} for i in op_types]...}
+
+trig_types = [:Sin, :Cos, :Tan, :Csc, :Sec, :Cot, :ASin, :ACos, :ATan, :ACsc, :ASec, :ACot]
+BasicTrigFunction =  Union{[SymEngine.BasicType{Val{i}} for i in trig_types]...}
+
+
+
+
+
+Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic
+Base.promote_rule{T<:BasicType, S<:Number}(::Type{T}, ::Type{S} ) = T
+
+Base.promote_type{T}(::Type{BasicType{Val{T}}}, ::Type{Basic}) = BasicType{Val{T}}
+Base.promote_type{T}(::Type{Basic}, ::Type{BasicType{Val{T}}}) = BasicType{Val{T}}
+
+
+
+Base.convert{T<:BasicType}(::Type{Basic}, val::T) = val.x
+Base.convert{T<:BasicType}(::Type{T}, val::Integer) = T(Basic(val))
+Base.convert{T<:BasicType}(::Type{T}, val::Rational) = T(Basic(val))
+
+
+
+## We have Basic and BasicType{...}. We go back and forth with:
+## Basic(b::BasicType) and Sym(b::Basic)
+_Sym(x::Any) = convert(BasicType, Basic(x))
 
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -126,7 +126,7 @@ type BasicType{T} <: Number
 end
 
 SymbolicType = Union{Basic, BasicType}
-
+convert(::Type{Basic}, x::BasicType) = x.x
 Basic(x::BasicType) = x.x
 
 function get_type(s::Basic)

--- a/src/types.jl
+++ b/src/types.jl
@@ -20,7 +20,6 @@ type Basic  <: Number
         return z
     end
 end
-export Basic
 
 
 basic_free(b::Basic) = ccall((:basic_free_stack, :libsymengine), Void, (Ptr{Basic}, ), &b)
@@ -59,8 +58,8 @@ convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
 Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic
 
 ## Class ID
-get_type(s::Basic) = convert(Int, ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s))
-get_class_from_id(id::Int) = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (Int,), id) |> bytestring
+get_type(s::Basic) = ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
+get_class_from_id(id::UInt) = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (UInt,), id) |> bytestring
 "Get SymEngine class of an object (e.g. 1=>:Integer, 1//2 =:Rational, sin(x) => :Sin, ..."
 get_symengine_class(s::Basic) = symbol(get_class_from_id(get_type(s)))
 
@@ -68,7 +67,7 @@ get_symengine_class(s::Basic) = symbol(get_class_from_id(get_type(s)))
 function free_symbols(ex::Basic)
     syms = CSetBasic()
     ccall((:basic_free_symbols, :libsymengine), Void, (Ptr{Basic}, Ptr{Void}), &ex, syms.ptr)
-    convert(Set, syms)
+    convert(Vector, syms)
 end
 
 "Return arguments of a function call as a vector of `Basic` objects"
@@ -110,7 +109,6 @@ function symbols(s::ASCIIString)
     Base.length(by_space) == 1 && return symbols(symbol(s))
     tuple([_symbol(symbol(o)) for o in by_space]...)
 end
-export symbols
 
 
 
@@ -141,7 +139,6 @@ macro vars(x...)
     push!(q.args, Expr(:tuple, x...))
     eval(Main, q)
 end
-export @vars
 
 
 ## We also have a wrapper type that can be used to control dispatch

--- a/src/types.jl
+++ b/src/types.jl
@@ -54,12 +54,19 @@ else
 end
 convert(::Type{Basic}, x::Integer) = Basic(BigInt(x))
 convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
+convert(::Type{Basic}, x::Complex) = Basic(real(x)) + Basic(imag(x)) * IM
 
 Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic
 
 ## Class ID
 get_type(s::Basic) = ccall((:basic_get_type, :libsymengine), UInt, (Ptr{Basic},), &s)
-get_class_from_id(id::UInt) = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (UInt,), id) |> bytestring
+function get_class_from_id(id::UInt)
+    a = ccall((:basic_get_class_from_id, :libsymengine), Ptr{UInt8}, (Int,), id)
+    str = bytestring(a)
+    ccall((:basic_str_free, :libsymengine), Void, (Ptr{UInt8}, ), a)
+    str
+end
+
 "Get SymEngine class of an object (e.g. 1=>:Integer, 1//2 =:Rational, sin(x) => :Sin, ..."
 get_symengine_class(s::Basic) = symbol(get_class_from_id(get_type(s)))
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -173,9 +173,8 @@ BasicTrigFunction =  Union{[SymEngine.BasicType{Val{i}} for i in trig_types]...}
 
 Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic
 Base.promote_rule{T<:BasicType, S<:Number}(::Type{T}, ::Type{S} ) = T
-
-Base.promote_type{T}(::Type{BasicType{Val{T}}}, ::Type{Basic}) = BasicType{Val{T}}
-Base.promote_type{T}(::Type{Basic}, ::Type{BasicType{Val{T}}}) = BasicType{Val{T}}
+Base.promote_rule{T<:BasicType}(::Type{T}, ::Type{Basic} ) = T
+Base.promote_rule{T<:BasicType}( ::Type{Basic}, ::Type{T} ) = T
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,13 @@
 using Base.Test
-import SymEngine
+using SymEngine
 
-x = SymEngine.symbol("x")
-y = SymEngine.symbol("y")
+x = SymEngine._symbol("x")
+y = SymEngine._symbol("y")
+@syms z
 
 a = x^2 + x/2 - x*y*5
 b = SymEngine.diff(a, x)
-@test b == 2*x + Rational(1, 2) - 5*y
+@test b == 2*x + 1//2 - 5*y
 
 c = x + Rational(1, 5)
 c = SymEngine.expand(c * 5)
@@ -26,3 +27,19 @@ show(a)
 println()
 show(b)
 println()
+
+
+## mathfuns
+@test abs(Basic(-1)) == 1
+@test sin(Basic(1)) == subs(sin(x), x, 1)
+@test sin(PI) == 0
+@test subs(sin(x), x, pi) == 0
+@test sind(Basic(30)) == 1 // 2
+
+## subs
+ex = x^2 + y^2
+@test subs(ex, x, 1) == 1 + y^2
+@test subs(ex, (x, 1)) == 1 + y^2
+@test subs(ex, x => 1) == 1 + y^2
+@test subs(ex, (x,1), (y,2)) == 1 + 2^2
+@test subs(ex, x => 1, y => 2) == 1 + 2^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,21 @@ println()
 @test subs(sin(x), x, pi) == 0
 @test sind(Basic(30)) == 1 // 2
 
+## calculus
+x,y = symbols("x y")
+n = Basic(2)
+ex = sin(x*y)
+@test diff(log(x),x) == 1/x
+@test diff(ex, x) == y * cos(x*y)
+@test diff(ex, x, 2) == diff(diff(ex,x), x)
+@test diff(ex, x, n) == diff(diff(ex,x), x)
+@test diff(ex, x, y) == diff(diff(ex,x), y)
+@test diff(ex, x, y,x) == diff(diff(diff(ex,x), y), x)
+@test series(sin(x), x, 0, 2) == x
+@test series(sin(x), x, 0, 3) == x - x^3/6
+   
+
+
 ## ntheory
 @test mod(Basic(10), Basic(4)) == 2
 @test mod(Basic(10), 4) == 2               # mod(::Basic, ::Number)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,15 +6,15 @@ y = Sym(:y)
 @syms z
 
 a = x^2 + x/2 - x*y*5
-b = SymEngine.diff(a, x)
+b = diff(a, x)
 @test b == 2*x + 1//2 - 5*y
 
 c = x + Rational(1, 5)
-c = SymEngine.expand(c * 5)
+c = expand(c * 5)
 @test c == 5*x + 1
 
 c = x ^ 5
-@test SymEngine.diff(c, x) == 5 * x ^ 4
+@test diff(c, x) == 5 * x ^ 4
 
 c = x ^ y
 @test c != y^x
@@ -48,12 +48,18 @@ ex = x^2 + y^2
 ## type information
 a = Basic(1)
 b = Basic(1//2)
-@test isa(SymEngine._Sym(a+a), SymEngine.BasicType{Val{:Integer}})
-@test isa(SymEngine._Sym(a+b), SymEngine.BasicType{Val{:Rational}})
+@test isa(SymEngine.BasicType(a+a), SymEngine.BasicType{Val{:Integer}})
+@test isa(SymEngine.BasicType(a+b), SymEngine.BasicType{Val{:Rational}})
 
 ## can we do math with items of BasicType?
-a1 = SymEngine._Sym(a)
+a1 = SymEngine.BasicType(a)
 tot = a1
 for i in 1:100  tot = tot + a1 end
 @test tot == 101
 sin(a1)
+
+## N, not exported. Just a test for now
+a = Basic(1)
+@test SymEngine.N(a) == 1
+@test SymEngine.N(Basic(1//2)) == 1//2
+@test SymEngine.N(Basic(12345678901234567890)) == 12345678901234567890

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -48,5 +48,5 @@ ex = x^2 + y^2
 ## type information
 a = Sym(1)
 b = Sym(1//2)
-@test isa(a+a, SymEngine.BasicInteger)
-@test isa(a+b, SymEngine.BasicRational)
+@test isa(a+a, SymEngine.BasicType{Val{:Integer}})
+@test isa(a+b, SymEngine.BasicType{Val{:Rational}})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,11 +30,11 @@ println()
 
 
 ## mathfuns
-@test abs(Sym(-1)) == 1
-@test sin(Sym(1)) == subs(sin(x), x, 1)
+@test abs(Basic(-1)) == 1
+@test sin(Basic(1)) == subs(sin(x), x, 1)
 @test sin(PI) == 0
 @test subs(sin(x), x, pi) == 0
-@test sind(Sym(30)) == 1 // 2
+@test sind(Basic(30)) == 1 // 2
 
 ## subs
 ex = x^2 + y^2
@@ -46,7 +46,14 @@ ex = x^2 + y^2
 
 
 ## type information
-a = Sym(1)
-b = Sym(1//2)
-@test isa(a+a, SymEngine.BasicType{Val{:Integer}})
-@test isa(a+b, SymEngine.BasicType{Val{:Rational}})
+a = Basic(1)
+b = Basic(1//2)
+@test isa(SymEngine._Sym(a+a), SymEngine.BasicType{Val{:Integer}})
+@test isa(SymEngine._Sym(a+b), SymEngine.BasicType{Val{:Rational}})
+
+## can we do math with items of BasicType?
+a1 = SymEngine._Sym(a)
+tot = a1
+for i in 1:100  tot = tot + a1 end
+@test tot == 101
+sin(a1)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -36,6 +36,14 @@ println()
 @test subs(sin(x), x, pi) == 0
 @test sind(Basic(30)) == 1 // 2
 
+## ntheory
+@test mod(Basic(10), Basic(4)) == 2
+@test mod(Basic(10), 4) == 2               # mod(::Basic, ::Number)
+@test_throws MethodError mod(10, Basic(4)) # no mod(::Number, ::Basic)
+@test gcd(Basic(10), Basic(4)) == 2
+@test lcm(Basic(10), Basic(4)) == 20
+@test binomial(Basic(5), 2) == 10
+
 ## subs
 ex = x^2 + y^2
 @test subs(ex, x, 1) == 1 + y^2

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -44,14 +44,6 @@ println()
 @test lcm(Basic(10), Basic(4)) == 20
 @test binomial(Basic(5), 2) == 10
 
-## subs
-ex = x^2 + y^2
-@test subs(ex, x, 1) == 1 + y^2
-@test subs(ex, (x, 1)) == 1 + y^2
-@test subs(ex, x => 1) == 1 + y^2
-@test subs(ex, (x,1), (y,2)) == 1 + 2^2
-@test subs(ex, x => 1, y => 2) == 1 + 2^2
-
 
 ## type information
 a = Basic(1)
@@ -66,11 +58,24 @@ for i in 1:100  tot = tot + a1 end
 @test tot == 101
 sin(a1)
 
-## N, not exported. Just a test for now
+## subs
+ex = x^2 + y^2
+@test subs(ex, x, 1) == 1 + y^2
+@test subs(ex, (x, 1)) == 1 + y^2
+@test subs(ex, x => 1) == 1 + y^2
+@test subs(ex, (x,1), (y,2)) == 1 + 2^2
+@test subs(ex, x => 1, y => 2) == 1 + 2^2
+
+## lambidfy
+@test_approx_eq lambdify(sin(Basic(1))) sin(1)
+ex = sin(x)
+@test_approx_eq lambdify(ex)(1) sin(1)
+
+## N
 a = Basic(1)
-@test SymEngine.N(a) == 1
-@test SymEngine.N(Basic(1//2)) == 1//2
-@test SymEngine.N(Basic(12345678901234567890)) == 12345678901234567890
+@test N(a) == 1
+@test N(Basic(1//2)) == 1//2
+@test N(Basic(12345678901234567890)) == 12345678901234567890
 
 
 ## generic linear algebra

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,9 @@
 using Base.Test
 using SymEngine
 
-x = Sym("x")
-y = Sym(:y)
-@syms z
+x = symbols("x")
+y = symbols(:y)
+@vars z
 
 a = x^2 + x/2 - x*y*5
 b = diff(a, x)
@@ -19,7 +19,7 @@ c = x ^ 5
 c = x ^ y
 @test c != y^x
 
-c = Sym(-5)
+c = Basic(-5)
 @test abs(c) == 5
 @test abs(c) != 4
 
@@ -63,3 +63,11 @@ a = Basic(1)
 @test SymEngine.N(a) == 1
 @test SymEngine.N(Basic(1//2)) == 1//2
 @test SymEngine.N(Basic(12345678901234567890)) == 12345678901234567890
+
+
+## generic linear algebra
+x = symbols("x")
+A = [x 2; x 1]
+@test det(A) == -x
+@test det(inv(A)) == - 1/x
+(A \ [1,2])[1] == 3/x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,8 @@
 using Base.Test
 using SymEngine
 
-x = SymEngine._symbol("x")
-y = SymEngine._symbol("y")
+x = Sym("x")
+y = Sym(:y)
 @syms z
 
 a = x^2 + x/2 - x*y*5
@@ -19,7 +19,7 @@ c = x ^ 5
 c = x ^ y
 @test c != y^x
 
-c = SymEngine.Basic(-5)
+c = Sym(-5)
 @test abs(c) == 5
 @test abs(c) != 4
 
@@ -30,11 +30,11 @@ println()
 
 
 ## mathfuns
-@test abs(Basic(-1)) == 1
-@test sin(Basic(1)) == subs(sin(x), x, 1)
+@test abs(Sym(-1)) == 1
+@test sin(Sym(1)) == subs(sin(x), x, 1)
 @test sin(PI) == 0
 @test subs(sin(x), x, pi) == 0
-@test sind(Basic(30)) == 1 // 2
+@test sind(Sym(30)) == 1 // 2
 
 ## subs
 ex = x^2 + y^2
@@ -43,3 +43,10 @@ ex = x^2 + y^2
 @test subs(ex, x => 1) == 1 + y^2
 @test subs(ex, (x,1), (y,2)) == 1 + 2^2
 @test subs(ex, x => 1, y => 2) == 1 + 2^2
+
+
+## type information
+a = Sym(1)
+b = Sym(1//2)
+@test isa(a+a, SymEngine.BasicInteger)
+@test isa(a+b, SymEngine.BasicRational)


### PR DESCRIPTION
Dear @isuruf, this pull request is similar in spirit to #18, but that got messed up. I'm closing that one and its sister request.

This keeps most objects as `Basic` objects, though does allow for dispatch on the SymEngine class through the `BasicType` class. The `diff` function and `N` function show a possible use case. Attempting to satisfy both Julia's type system and SymEngines at the same time proved difficult. I think this approach is a reasonable workaround.

There is one area that I could use some help with. The `ctypes.jl` file attempts to provide the CSetBasic and CVecBasic classes on the julia side so that `free_symbols` and `get_args` can be implemented. Both have issues: free symbols crashes right away, and get_args crashes eventually, though occasionally works as expected. I think I am not creating the finalizer correctly, but this is not an area I know much about.