### PR TITLE
remove `eval` use in `@vars`. Now works in local scope

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -128,10 +128,10 @@ macro vars(x...)
     end
     for s in x
         @assert isa(s,Symbol) "@syms expected a list of symbols"
-        push!(q.args, Expr(:(=), s, Expr(:call, :(SymEngine._symbol), Expr(:quote, s))))
+        push!(q.args, Expr(:(=), esc(s), Expr(:call, :(SymEngine._symbol), Expr(:quote, s))))
     end
-    push!(q.args, Expr(:tuple, x...))
-    eval(Main, q)
+    push!(q.args, Expr(:tuple, map(esc, x)...))
+    q
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,13 @@ x = symbols("x")
 y = symbols(:y)
 @vars z
 
+
+# make sure @vars defines in a local scope
+let
+    @vars w
+end
+@test_throws UndefVarError isdefined(w)
+
 a = x^2 + x/2 - x*y*5
 b = diff(a, x)
 @test b == 2*x + 1//2 - 5*y
@@ -48,8 +55,6 @@ ex = sin(x*y)
 @test diff(ex, x, y,x) == diff(diff(diff(ex,x), y), x)
 @test series(sin(x), x, 0, 2) == x
 @test series(sin(x), x, 0, 3) == x - x^3/6
-   
-
 
 ## ntheory
 @test mod(Basic(10), Basic(4)) == 2


### PR DESCRIPTION
Calling eval in a macro is usually bad form. This adds some calls to `esc` so that is no longer necessary.