### PR TITLE
Sl/0.5 compat

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,3 @@
 julia 0.4
-Compat 0.3.5
+Compat 0.8.5
 BinDeps

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -2,6 +2,8 @@ module SymEngine
 
 import Base: show, convert
 
+using Compat: String, unsafe_string, @compat
+
 export Basic, symbols, @vars
 export free_symbols, get_args
 export ascii_art
@@ -21,4 +23,3 @@ include("calculus.jl")
 
 
 end
-

--- a/src/calculus.jl
+++ b/src/calculus.jl
@@ -13,7 +13,7 @@ function diff{T<:SymbolicType}(b1::T, b2::BasicType{Val{:Symbol}})
     return a
 end
 
-diff{T<:SymbolicType}(b1::T, b2::BasicType) = throw(ArgumentError("Second argument must be of symbol type"))
+diff{T<:SymbolicType}(b1::T, b2::BasicType) = throw(ArgumentError("Second argument must be of Symbol type"))
 
 function diff{T<:SymbolicType, S<:SymbolicType}(b1::T, b2::S, n::Integer=1)
     n < 0 && throw(DomainError("n must be non-negative integer"))

--- a/src/display.jl
+++ b/src/display.jl
@@ -2,7 +2,7 @@
 function toString(b::SymbolicType)
     b = Basic(b)
     a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
-    string = bytestring(a)
+    string = unsafe_string(a)
     ccall((:basic_str_free, :libsymengine), Void, (Ptr{Int8}, ), a)
     string = replace(string, "**", "^") # de pythonify
     return string
@@ -15,8 +15,7 @@ Base.show(io::IO, b::SymbolicType) = print(io, toString(b))
 type AsciiArt x end
 function ascii_art()
     out = ccall((:ascii_art_str, :libsymengine),  Ptr{UInt8},  ())
-    AsciiArt(bytestring(out))
+    AsciiArt(unsafe_string(out))
 end
 
 Base.show(io::IO, x::AsciiArt) = print(io, x.x)
-

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -9,7 +9,7 @@ end
 
 ## main ops
 for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div), (:^, :pow))
-    tup = (Base.symbol("basic_$libnm"), :libsymengine)
+    tup = (Base.Symbol("basic_$libnm"), :libsymengine)
     @eval begin
         function ($op)(b1::Basic, b2::Basic)
             a = Basic()
@@ -39,14 +39,14 @@ Base.one(x::BasicType) = BasicType(Basic(1))
 Base.one{T<:BasicType}(::Type{T}) = BasicType(Basic(1))
 
 
-## Math constants 
+## Math constants
 ## no oo!
 for (op, libnm) in [(:IM, :I),
                  (:PI, :pi),
                  (:E, :E),
                  (:EulerGamma, :EulerGamma)
                  ]
-    tup = (Base.symbol("basic_const_$libnm"), :libsymengine)
+    tup = (Base.Symbol("basic_const_$libnm"), :libsymengine)
     @eval begin
         ($op) = begin
             a = Basic()
@@ -54,9 +54,9 @@ for (op, libnm) in [(:IM, :I),
             a
         end
     end
-    eval(Expr(:export, op)) 
+    eval(Expr(:export, op))
 end
-    
+
 ## ## Conversions
 Base.convert(::Type{Basic}, x::Irrational{:π}) = PI
 Base.convert(::Type{Basic}, x::Irrational{:e}) = E
@@ -68,6 +68,6 @@ Base.convert(::Type{BasicType}, x::Irrational) = BasicType(convert(Basic, x))
 
 
 ## Logical operators
-Base.(:<)(x::SymbolicType, y::SymbolicType) = N(x) < N(y)
-Base.(:<)(x::SymbolicType, y) = <(promote(x,y)...)
-Base.(:<)(x, y::SymbolicType) = <(promote(x,y)...)
+@compat Base.:<(x::SymbolicType, y::SymbolicType) = N(x) < N(y)
+@compat Base.:<(x::SymbolicType, y) = <(promote(x,y)...)
+@compat Base.:<(x, y::SymbolicType) = <(promote(x,y)...)

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -41,13 +41,13 @@ fn_map = Dict(
               :Abs => :abs # not really needed as default in map_fn covers this
               )
 
-map_fn(key, fn_map) = haskey(fn_map, key) ? fn_map[key] : symbol(lowercase(string(key)))
+map_fn(key, fn_map) = haskey(fn_map, key) ? fn_map[key] : Symbol(lowercase(string(key)))
 
 function walk_expression(ex)
     fn = get_symengine_class(ex)
     
     if fn == :Symbol
-        return symbol(toString(ex))
+        return Symbol(toString(ex))
     elseif fn in [:Integer , :Rational]
         return N(ex)
     elseif fn == :Complex
@@ -87,7 +87,7 @@ function _lambdify(ex::Basic, vars)
 
     try
         eval(Expr(:function,
-                  Expr(:call, gensym(), map(symbol,vars)...),
+                  Expr(:call, gensym(), map(Symbol,vars)...),
                   body))
     catch err
         throw(ArgumentError("Expression does not lambdify"))


### PR DESCRIPTION
Supports Julia 0.5 and 0.4 with no deprecation warnings.

This _should not_ be merged until after Compat.jl version 0.8.5 is tagged (hopefully soon).

This is on top of #25, sorry for not splitting them up. I'm just working on cleaning a few things up to incorporate SymEngine.jl in another package I'm working on.