### PR TITLE
add plotting recipes

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.4
+RecipesBase 0.0.6
 Compat 0.3.5
 BinDeps

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -18,7 +18,7 @@ include("mathfuns.jl")
 include("subs.jl")
 include("simplify.jl")
 include("calculus.jl")
-
+include("recipes.jl")
 
 end
 

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -1,0 +1,5 @@
+using RecipesBase
+
+## Plug into RecipesBase so plots of expressions treated like plots of functions
+@recipe f{T<:Basic}(::Type{T}, v::T) = lambdify(v)
+@recipe f{T<:Basic}(::Type{T}, v::T) = lambdify(v)

--- a/src/recipes.jl
+++ b/src/recipes.jl
@@ -2,4 +2,4 @@ using RecipesBase
 
 ## Plug into RecipesBase so plots of expressions treated like plots of functions
 @recipe f{T<:Basic}(::Type{T}, v::T) = lambdify(v)
-@recipe f{T<:Basic}(::Type{T}, v::T) = lambdify(v)
+@recipe f{S<:AbstractVector{Basic}}(::Type{S}, ss::S) = Function[lambdify(s) for s in ss]


### PR DESCRIPTION
With recent changes to `RecipesBase` this little change allows symbolic expressions to be plotted where functions can be used when plotting with `Plots`. Examples include plots of functions, contour plots, and surface plots. 