### PR TITLE
Fix toString

### DIFF
--- a/src/display.jl
+++ b/src/display.jl
@@ -1,9 +1,9 @@
 
 function toString(b::SymbolicType)
     b = Basic(b)
-    a = ccall((:basic_str, :libsymengine), Ptr{Int8}, (Ptr{Basic}, ), &b)
+    a = ccall((:basic_str, :libsymengine), Cstring, (Ptr{Basic}, ), &b)
     string = unsafe_string(a)
-    ccall((:basic_str_free, :libsymengine), Void, (Ptr{Int8}, ), a)
+    ccall((:basic_str_free, :libsymengine), Void, (Cstring, ), a)
     string = replace(string, "**", "^") # de pythonify
     return string
 end


### PR DESCRIPTION
Fix for the following error
```
julia> using SymEngine
julia> Basic(2)
Error showing value of type SymEngine.Basic:
ERROR: MethodError: `unsafe_string` has no method matching unsafe_string(::Ptr{Int8})
 in toString at /home/isuru/.julia/v0.4/SymEngine/src/display.jl:5
 in show at /home/isuru/.julia/v0.4/SymEngine/src/display.jl:11
 in anonymous at show.jl:1301
 in with_output_limit at ./show.jl:1278
 in showlimited at show.jl:1300
 in writemime at replutil.jl:4
 in display at REPL.jl:114
 in display at REPL.jl:117
 [inlined code] from multimedia.jl:151
 in display at multimedia.jl:163
 in print_response at REPL.jl:134
 in print_response at REPL.jl:121
 in anonymous at REPL.jl:624
 in run_interface at ./LineEdit.jl:1610
 in run_frontend at ./REPL.jl:863
 in run_repl at ./REPL.jl:167
 in _start at ./client.jl:420
```