### PR TITLE
Update REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,5 +1,5 @@
 julia 0.4
 Compat 0.8.5
 RecipesBase 0.0.6
-BinDeps
-Conda
+BinDeps 0.4.0
+Conda 0.3.0


### PR DESCRIPTION
Conda 0.3.0 is needed for building on Windows.