### PR TITLE
Add dense matrix methods, close #41

### DIFF
--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -12,8 +12,8 @@ export series
 
 include("../deps/deps.jl")
 
-include("ctypes.jl")
 include("types.jl")
+include("ctypes.jl")
 include("display.jl")
 include("mathops.jl")
 include("mathfuns.jl")
@@ -21,5 +21,5 @@ include("subs.jl")
 include("simplify.jl")
 include("calculus.jl")
 include("recipes.jl")
-
+include("dense-matrix.jl")
 end

--- a/src/ctypes.jl
+++ b/src/ctypes.jl
@@ -66,3 +66,67 @@ function Base.convert(::Type{Vector}, x::CVecBasic)
     n = Base.length(x)
     [x[i-1] for i in 1:n]
 end
+
+
+## Dense matrix
+
+type CDenseMatrix <: DenseArray{Basic, 2}
+    ptr::Ptr{Void}
+end
+
+Base.promote_rule{T <: Basic}(::Type{CDenseMatrix}, ::Type{Matrix{T}} ) = CDenseMatrix
+
+function CDenseMatrix_free(x::CDenseMatrix)
+    if x.ptr != C_NULL
+        ccall((:dense_matrix_free, libsymengine), Void, (Ptr{Void},), x.ptr)
+        x.ptr = C_NULL
+    end
+end
+
+function CDenseMatrix()
+    z = CDenseMatrix(ccall((:dense_matrix_new, libsymengine), Ptr{Void}, ()))
+    finalizer(z, CDenseMatrix_free)
+    z
+end
+
+function CDenseMatrix(m::Int, n::Int)
+    z = CDenseMatrix(ccall((:dense_matrix_new_rows_cols, libsymengine), Ptr{Void}, (Int, Int), m, n))
+    finalizer(z, CDenseMatrix_free)
+    z
+end
+
+
+function CDenseMatrix{T}(x::Array{T, 2})
+    r,c = size(x)
+    M = CDenseMatrix(r, c)
+    for j in 1:c
+        for i in 1:r ## fill column by column
+            M[i,j] = x[i,j]
+        end
+    end
+    M
+end
+
+
+function Base.convert(::Type{Matrix}, x::CDenseMatrix) 
+    m,n = Base.size(x)
+    [x[i,j] for i in 1:m, j in 1:n]
+end
+
+Base.convert{T}(::Type{CDenseMatrix}, x::Array{T, 2}) = CDenseMatrix(x)
+Base.convert{T}(::Type{CDenseMatrix}, x::Array{T, 1}) = convert(CDenseMatrix, reshape(x, length(x), 1))
+
+
+function toString(b::CDenseMatrix)
+    a = ccall((:dense_matrix_str, libsymengine), Cstring, (Ptr{Void}, ), b.ptr)
+    string = unsafe_string(a)
+    ccall((:basic_str_free, libsymengine), Void, (Cstring, ), a)
+    string = replace(string, "**", "^") # de pythonify
+    return string
+end
+
+function Base.show(io::IO, m::CDenseMatrix)
+    r, c = size(m)
+    println(io, "CDenseMatrix: $r x $c")
+    println(io, toString(m))
+end

--- a/src/dense-matrix.jl
+++ b/src/dense-matrix.jl
@@ -1,0 +1,180 @@
+## Dense matrix interface
+
+dense_matrix_rows(s::CDenseMatrix) = ccall((:dense_matrix_rows, libsymengine), Int, (Ptr{Void}, ), s.ptr)
+dense_matrix_cols(s::CDenseMatrix) = ccall((:dense_matrix_cols, libsymengine), Int, (Ptr{Void}, ), s.ptr)
+function dense_matrix_rows_cols(mat::CDenseMatrix, r::UInt, c::UInt)
+    ccall((:dense_matrix_rows_cols, libsymengine), Int, (Ptr{Void}, UInt, UInt), s.ptr, r, c)
+end
+
+
+function dense_matrix_get_basic(s::CDenseMatrix, r::Int, c::Int)
+    result = Basic()
+    ccall((:dense_matrix_get_basic, libsymengine), Void, (Ptr{Basic}, Ptr{Void}, UInt, UInt), &result, s.ptr, UInt(r), UInt(c))
+    result
+end
+
+
+function dense_matrix_set_basic(s::CDenseMatrix, val, r::Int, c::Int)
+    value = Basic(val)
+    ccall((:dense_matrix_set_basic, libsymengine), Void, (Ptr{Void}, UInt, UInt, Ptr{Basic}), s.ptr, UInt(r), UInt(c), &value)
+    value
+end
+
+
+
+## Basic operations det, inv, transpose
+function dense_matrix_det(s::CDenseMatrix)
+    result = Basic()
+    ccall((:dense_matrix_det, libsymengine), Void, (Ptr{Basic}, Ptr{Void}), &result, s.ptr)
+    result
+end
+function dense_matrix_inv(s::CDenseMatrix)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_inv, libsymengine), Void, (Ptr{Void}, Ptr{Void}), result.ptr, s.ptr)
+    result
+end
+
+
+function dense_matrix_transpose(s::CDenseMatrix)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_transpose, libsymengine), Void, (Ptr{Void}, Ptr{Void}), result.ptr, s.ptr)
+    result
+end
+
+## dense_matrix_submatrix...
+
+
+## some matrix arithmetic methods
+## These are unncecessary, as +,-,*,^ are inhertied by the AbstractArray Interface. Those return Array{Basic,2}. These
+## return CDenseMatrix objects.
+function dense_matrix_add_matrix(a::CDenseMatrix, b::CDenseMatrix)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_add_matrix, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), result.ptr, a.ptr, b.ptr)
+    result
+end
+
+
+function dense_matrix_mul_matrix(a::CDenseMatrix, b::CDenseMatrix)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_mul_matrix, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), result.ptr, a.ptr, b.ptr)
+    result
+end
+
+function dense_matrix_add_scalar(a::CDenseMatrix, b::Basic)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_add_scalar, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), result.ptr, a.ptr, b.ptr)
+    result
+end
+
+
+function dense_matrix_mul_scalar(a::CDenseMatrix, b::Basic)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_mul_scalar, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), result.ptr, a.ptr, b.ptr)
+    result
+end
+
+
+## Factorizations ##################################################
+function dense_matrix_LU(mat::CDenseMatrix)
+    ## need square?
+    L = CDenseMatrix()
+    U = CDenseMatrix()
+    ccall((:dense_matrix_LU, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), L.ptr, U.ptr,  mat.ptr)
+    (L, U)
+end
+
+## LDL decomposition
+function dense_matrix_LDL(mat::CDenseMatrix)
+    L = CDenseMatrix()
+    D = CDenseMatrix()
+    ccall((:dense_matrix_LDL, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), L.ptr, D.ptr,  mat.ptr)
+    (L, D)
+end
+
+##  Fraction free LU factorization
+function dense_matrix_FFLU(mat::CDenseMatrix)
+    LU = CDenseMatrix()
+    ccall((:dense_matrix_FFLU, libsymengine), Void, (Ptr{Void}, Ptr{Void}), LU.ptr, mat.ptr)
+    LU
+end
+
+## Fraction free LDU factorization
+function dense_matrix_FFLDU(mat::CDenseMatrix)
+    L = CDenseMatrix()
+    D = CDenseMatrix()
+    U = CDenseMatrix()
+    
+    ccall((:dense_matrix_FFLDU, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}, Ptr{Void}), L.ptr, D.ptr, U.ptr, mat.ptr)
+    (L, D, U)
+end
+
+function dense_matrix_LU_solve(A::CDenseMatrix, b::CDenseMatrix)
+    x = CDenseMatrix()
+    ccall((:dense_matrix_LU_solve, libsymengine), Void, (Ptr{Void}, Ptr{Void}, Ptr{Void}), x.ptr, A.ptr, b.ptr)
+    x
+end
+
+
+function dense_matrix_zeros(::Type{CDenseMatrix}, r::Int, c::Int)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_zeros, libsymengine), Void, (Ptr{Void}, UInt, UInt), result.ptr, UInt(r), UInt(c))
+    result
+end
+
+
+function dense_matrix_ones(r::Int, c::Int)
+    result = CDenseMatrix()
+    ccall((:dense_matrix_ones, libsymengine), Void, (Ptr{Void}, UInt, UInt), result.ptr, UInt(r), UInt(c))
+    result
+end
+
+## dense_matrix_diag
+
+function dense_matrix_eye(N::Int, M::Int, k::Int=0)
+    s = CDenseMatrix()
+    ccall((:dense_matrix_eye, libsymengine), Void, (Ptr{Void}, UInt, UInt, Int), result.ptr, UInt(N), UInt(M), k)
+    s
+end
+
+dense_matrix_eq(a::CDenseMatrix, b::CDenseMatrix) = ccall((:dense_matrix_eq, libsymengine), Int, (Ptr{Void},Ptr{Void}), a.ptr, b.ptr)
+
+## Plug into Julia's interface ##################################################
+
+import Base: ==
+==(a::CDenseMatrix, b::CDenseMatrix)  = dense_matrix_eq(a, b) == 1
+
+## Abstract Array Interface
+Base.size(s::CDenseMatrix) = (dense_matrix_rows(s), dense_matrix_cols(s))
+Base.getindex(s::CDenseMatrix, r::Int, c::Int) = dense_matrix_get_basic(s, r-1, c-1)
+Base.setindex!(s::CDenseMatrix, val, r::Int, c::Int) = dense_matrix_set_basic(s, val, r-1, c-1)
+
+## special matrices
+Base.zeros(::Type{CDenseMatrix}, r::Int, c::Int) = dense_matrix_zeros(s, r-1, c-1)
+Base.ones(::Type{CDenseMatrix}, r::Int, c::Int) = dense_matrix_ones(r-1, c-1)
+Base.eye(::Type{CDenseMatrix}, n::Integer) = convert(CDenseMatrix, eye(Basic, n))
+
+
+## basic functions
+Base.det(s::CDenseMatrix) = dense_matrix_det(s)
+Base.inv(s::CDenseMatrix) = dense_matrix_inv(s)
+Base.transpose(s::CDenseMatrix) = dense_matrix_transpose(s)
+
+Base.factorize(M::CDenseMatrix) = factorize(convert(Matrix, M))
+
+"""
+LU decomposition for CDenseMatrix, dense matrices of symbolic values
+
+Also: lufact(a, val{:false}) for non-pivoting lu factorization
+"""
+function Base.lu(a::CDenseMatrix)
+    l, u = dense_matrix_LU(a)
+    convert(Matrix, l), convert(Matrix, u), eye(Basic, size(l)[1])
+end
+Base.lu{T <: Basic}(a::Array{T,2}) = lu(convert(CDenseMatrix, a))
+
+
+# solve using LU_solve
+import Base: \
+\(A::CDenseMatrix, b::CDenseMatrix) = dense_matrix_LU_solve(A, b)
+\(A::CDenseMatrix, b::Vector) = A \ convert(CDenseMatrix, [convert(Basic,u) for u in b])
+    

--- a/src/dense-matrix.jl
+++ b/src/dense-matrix.jl
@@ -41,7 +41,12 @@ function dense_matrix_transpose(s::CDenseMatrix)
     result
 end
 
-## dense_matrix_submatrix...
+function dense_matrix_submatrix(mat::CDenseMatrix, r1::Int, c1::Int, r2::Int, c2::Int, r::Int, c::Int)
+    s = CDenseMatrix()
+    ccall((:dense_matrix_inv, libsymengine), Void, (Ptr{Void}, Ptr{Void}, UInt, UInt, UInt, UInt, UInt, UInt),
+          s.ptr, mat.ptr, UInt(r1), UInt(c1), UInt(r2), UInt(c2), UInt(r), UInt(c))
+    s
+end
 
 
 ## some matrix arithmetic methods
@@ -128,7 +133,7 @@ function dense_matrix_ones(r::Int, c::Int)
     result
 end
 
-## dense_matrix_diag
+## dense_matrix_diag XXX don't have CVecBasic constructor
 
 function dense_matrix_eye(N::Int, M::Int, k::Int=0)
     s = CDenseMatrix()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using Base.Test
 using SymEngine
 
+include("test-dense-matrix.jl")
+
 x = symbols("x")
 y = symbols(:y)
 @vars z

--- a/test/test-dense-matrix.jl
+++ b/test/test-dense-matrix.jl
@@ -1,0 +1,40 @@
+using Base.Test
+using SymEngine
+CDenseMatrix = SymEngine.CDenseMatrix
+
+@vars x
+
+# constructors
+A = [x 1 2; 3 x 4; 5 6 x]
+M = convert(CDenseMatrix, A)
+M = CDenseMatrix(A)
+
+# abstract interface
+@test M[1,1] == A[1,1]
+for i in eachindex(M)
+    @test M[i] == A[i]
+end
+M[1,1] = x^2
+@test M[1,1] == x^2
+M[1,1] = x
+
+# inherits from DenseArray
+@test all(M + 3 .== A + 3)
+@test all(M * 3 .== A * 3)
+@test all(M + M .== A + A)
+@test all(M * M .== A * A)
+@test all(M' .== A')
+
+# generic det
+@test prod([subs(det(M) - det(A), x, i) == 0 for i in 2:10]) == true
+@test inv(M) - inv(A) == zeros(Basic, 3,3)
+
+# factorizations
+@test lu(M) == lu(A)
+
+A = [x 1 2; 0 x 4; 0 0 x]
+b = [1, 2, 3]
+M = convert(CDenseMatrix, A)
+out = M \ b
+@test M * out - b == zeros(Basic, 3, 1)
+


### PR DESCRIPTION
This adds the methods for dense matrix from the c wrapper. It should be checked to see that I'm doing things properly. The fact that `CDenseMatrix` is set up to inherit from `DenseArray{Basic,2}` means that the matrix algebra of Julia comes along for free. Though this has some cost, as currently set up, as the results end up as a `Array{Basic,2}` and not `CDenseMatrix`. I'm not sure that is a bad thing (I don't think it is), but it may have ramifications. I didn't check, but it could possible by done differently.