### PR TITLE
Precompile sources

### DIFF
--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -1,3 +1,5 @@
+__precompile__()
+
 module SymEngine
 
 import Base: show, convert, real, imag
@@ -9,7 +11,6 @@ export free_symbols, get_args
 export ascii_art
 export subs, lambdify, N
 export series
-
 
 const deps_file = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
 
@@ -30,4 +31,7 @@ include("simplify.jl")
 include("calculus.jl")
 include("recipes.jl")
 include("dense-matrix.jl")
+
+__init__() = init_constants()
+
 end

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -41,20 +41,26 @@ Base.one{T<:BasicType}(::Type{T}) = BasicType(Basic(1))
 
 ## Math constants
 ## no oo!
-for (op, libnm) in [(:IM, :I),
-                 (:PI, :pi),
-                 (:E, :E),
-                 (:EulerGamma, :EulerGamma)
-                 ]
-    tup = (Base.Symbol("basic_const_$libnm"), libsymengine)
+
+for op in [:IM, :PI, :E, :EulerGamma]
     @eval begin
-        ($op) = begin
-            a = Basic()
-            ccall($tup, Void, (Ptr{Basic}, ), &a)
-            a
-        end
+        const $op = Basic()
     end
     eval(Expr(:export, op))
+end
+
+function init_constants()
+    for (op, libnm) in [(:IM, :I),
+                     (:PI, :pi),
+                     (:E, :E),
+                     (:EulerGamma, :EulerGamma)
+                     ]
+        tup = (Base.Symbol("basic_const_$libnm"), libsymengine)
+        @eval begin
+            ccall((:basic_new_stack, libsymengine), Void, (Ptr{Basic}, ), &($op))
+            ccall($tup, Void, (Ptr{Basic}, ), &($op))
+        end
+    end
 end
 
 ## ## Conversions


### PR DESCRIPTION
constants are initialized not at build time, but at load time by
using `__init__` function
