### PR TITLE
Address #54

### DIFF
--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -124,9 +124,6 @@ end
         
 
 ##  Conversions SymEngine -> Julia 
-## define convert(T, x) methods leveraging N()
-convert{T <: Union{Int, BigInt,  Float64, BigFloat, Real}}(::Type{T}, x::Basic) = convert(T, BasicType(x))
-convert{T <: Union{Int, BigInt,  Float64, BigFloat, Real}}(::Type{T}, x::BasicType) = convert(T, N(x))
 
 ## Rational: TODO: follow symengine/symengine#1143 for support in the cwrapper
 den(x::Basic)                     = den(BasicType(x))
@@ -141,9 +138,6 @@ num(x::BasicType{Val{:Rational}}) = Basic(String(copy(split(SymEngine.toString(x
 num(x::BasicComplexNumber)        = imag(x) == Basic(0) ? num(real(x)) : throw(InexactError())
 num(x::BasicType)                 = throw(InexactError())
 
-convert{T}(::Type{Rational{T}}, x::Basic) = convert(Rational{T}, BasicType(x))
-convert{T}(::Type{Rational{T}}, x::BasicType) = Rational(convert(T, num(x)), convert(T, den(x)))
-
 
 ## Complex
 real(x::Basic) = real(SymEngine.BasicType(x))
@@ -156,9 +150,15 @@ imag(x::BasicType{Val{:RealMPFR}}) = Basic(0)
 imag(x::BasicType{Val{:Rational}}) = Basic(0)
 imag(x::SymEngine.BasicType) = throw(InexactError())
 
-convert{T}(::Type{Complex{T}}, x::Basic) = convert(Complex{T}, BasicType(x))
-convert{T}(::Type{Complex{T}}, x::BasicType) = complex(convert(T, real(x)), convert(T, imag(x)))
 
+convert(::Type{Complex{Float64}}, x::Basic)  = convert(Complex{Float64}, N(evalf(x, 53, false)))
+convert(::Type{Complex{BigFloat}}, x::Basic) = convert(Complex{Float64}, N(evalf(x, precision(BigFloat), false)))
+convert{T}(::Type{Complex{T}}, x::Basic)     = complex(convert(T, real(x)), convert(T, imag(x)))
+
+## define convert(T, x) methods leveraging N()
+convert(::Type{Float64}, x::Basic)      = convert(Float64, N(evalf(x, 53, true)))
+convert(::Type{BigFloat}, x::Basic)     = convert(BigFloat, N(evalf(x, precision(BigFloat), true)))
+convert{T <: Real}(::Type{T}, x::Basic) = convert(T, N(x))
 
 
 ## For generic programming in Julia

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -150,15 +150,12 @@ imag(x::BasicType{Val{:RealMPFR}}) = Basic(0)
 imag(x::BasicType{Val{:Rational}}) = Basic(0)
 imag(x::SymEngine.BasicType) = throw(InexactError())
 
-
-convert(::Type{Complex{Float64}}, x::Basic)  = convert(Complex{Float64}, N(evalf(x, 53, false)))
-convert(::Type{Complex{BigFloat}}, x::Basic) = convert(Complex{Float64}, N(evalf(x, precision(BigFloat), false)))
-convert{T}(::Type{Complex{T}}, x::Basic)     = complex(convert(T, real(x)), convert(T, imag(x)))
-
 ## define convert(T, x) methods leveraging N()
-convert(::Type{Float64}, x::Basic)      = convert(Float64, N(evalf(x, 53, true)))
-convert(::Type{BigFloat}, x::Basic)     = convert(BigFloat, N(evalf(x, precision(BigFloat), true)))
-convert{T <: Real}(::Type{T}, x::Basic) = convert(T, N(x))
+convert(::Type{Float64}, x::Basic)           = convert(Float64, N(evalf(x, 53, true)))
+convert(::Type{BigFloat}, x::Basic)          = convert(BigFloat, N(evalf(x, precision(BigFloat), true)))
+convert(::Type{Complex{Float64}}, x::Basic)  = convert(Complex{Float64}, N(evalf(x, 53, false)))
+convert(::Type{Complex{BigFloat}}, x::Basic) = convert(Complex{BigFloat}, N(evalf(x, precision(BigFloat), false)))
+convert{T <: Number}(::Type{T}, x::Basic)    = convert(T, N(x))
 
 
 ## For generic programming in Julia

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -107,7 +107,7 @@ function N(b::BasicType{Val{:Integer}})
     end
 end
 
-N(b::BasicType{Val{:Rational}}) = Rational(N(num(b)), N(den(b))) # TODO: Implement rational_get_mpq in cwrapper.h
+N(b::BasicType{Val{:Rational}}) = Rational(N(num(b)), N(den(b))) # TODO: conditionally wrap rational_get_mpq from cwrapper.h
 N(b::BasicType{Val{:RealDouble}}) = convert(Cdouble, b)
 N(b::BasicType{Val{:RealMPFR}}) = convert(BigFloat, b)
 
@@ -128,7 +128,7 @@ end
 convert{T <: Union{Int, BigInt,  Float64, BigFloat, Real}}(::Type{T}, x::Basic) = convert(T, BasicType(x))
 convert{T <: Union{Int, BigInt,  Float64, BigFloat, Real}}(::Type{T}, x::BasicType) = convert(T, N(x))
 
-## Rational
+## Rational: TODO: follow symengine/symengine#1143 for support in the cwrapper
 den(x::Basic)                     = den(BasicType(x))
 den(x::BasicType{Val{:Integer}})  = Basic(1)
 den(x::BasicType{Val{:Rational}}) = Basic(String(copy(split(SymEngine.toString(x), "/"))[2]))
@@ -172,14 +172,14 @@ isless(x::Basic, y::Basic) = isless(N(x), N(y))
 
 
 ## These should have support in symengine-wrapper, but currently don't
-trunc(x::Basic, args...) = Basic(trunc(Float64(x), args...))  
+trunc(x::Basic, args...) = Basic(trunc(N(x), args...))  
 trunc{T <: Integer}(::Type{T},x::Basic, args...) = convert(T, trunc(x,args...))
 
-ceil(x::Basic) = Basic(ceil(Float64(x)))
+ceil(x::Basic) = Basic(ceil(N(x)))
 ceil{T <: Integer}(::Type{T},x::Basic) = convert(T, ceil(x))
 
-floor(x::Basic) = Basic(floor(Float64(x)))
+floor(x::Basic) = Basic(floor(N(x)))
 floor{T <: Integer}(::Type{T},x::Basic) = convert(T, floor(x))
 
-round(x::Basic) = Basic(round(Float64(x)))
+round(x::Basic) = Basic(round(N(x)))
 round{T <: Integer}(::Type{T},x::Basic) = convert(T, round(x))

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -1,9 +1,19 @@
-# N
-"""
+import Base: convert, real, imag, num, den
+import Base: isfinite, isnan, isinf, isless
+import Base: trunc, ceil, floor, round
 
-Convert a SymEngine numeric value into a number
 
-"""
+function evalf(b::Basic, bits::Integer=53, real::Bool=false)
+    c = Basic()
+    status = ccall((:basic_evalf, libsymengine), Cint, (Ptr{Basic}, Ptr{Basic}, Culong, Cint), &c, &b, Culong(bits), Int(real))
+    if status == 0
+        return c
+    else
+        throw(ArgumentError("libsymengine has to be compiled with MPFR and MPC for eval with precision greater than 53."))
+    end
+end
+
+## Conversions from SymEngine -> Julia at the ccall level
 function convert(::Type{BigInt}, b::BasicType{Val{:Integer}})
     a = BigInt()
     c = Basic(b)
@@ -11,13 +21,18 @@ function convert(::Type{BigInt}, b::BasicType{Val{:Integer}})
     return a
 end
 
+
+function convert(::Type{BigFloat}, b::BasicType{Val{:RealMPFR}})
+    c = Basic(b)
+    a = BigFloat()
+    ccall((:real_mpfr_get, libsymengine), Void, (Ptr{BigFloat}, Ptr{Basic}), &a, &c)
+    return a
+end
+
 function convert(::Type{Cdouble}, b::BasicType{Val{:RealDouble}})
     c = Basic(b)
     return ccall((:real_double_get_d, libsymengine), Cdouble, (Ptr{Basic},), &c)
 end
-
-real(b::BasicRealNumber) = b
-imag(b::BasicRealNumber) = b
 
 function real(b::BasicType{Val{:ComplexDouble}})
     c = Basic(b)
@@ -61,16 +76,98 @@ function imag(b::BasicType{Val{:ComplexMPC}})
     return a
 end
 
+
 function convert(::Type{Complex{Cdouble}}, b::BasicType{Val{:ComplexDouble}})
     return complex(convert(Cdouble, real(b)), convert(Cdouble, imag(b)))
 end
 
-function convert(::Type{BigFloat}, b::BasicType{Val{:RealMPFR}})
-    c = Basic(b)
-    a = BigFloat()
-    ccall((:real_mpfr_get, libsymengine), Void, (Ptr{BigFloat}, Ptr{Basic}), &a, &c)
-    return a
-end
+
+##  Conversions SymEngine -> Julia being more systematic
+##need Int, BigInt,  Float64, BigFloat, Complex{T} Rational{Int}, Rational{BigInt},
+##BasicTypes: Integer, Rational, RealDouble, RealMPFR, :Complex, :ComplexDouble, :ComplexMPC
+
+## Int
+convert(::Type{Int}, x::Basic) = convert(Int, BasicType(x))
+convert(::Type{Int}, x::BasicType{Val{:Integer}}) = convert(Int, convert(BigInt,x))
+convert(::Type{Int}, x::BasicType{Val{:Rational}}) = den(x) == 1 ? convert(Int, num(x)) : throw(InexactError())
+convert(::Type{Int}, x::BasicType{Val{:RealDouble}}) = convert(Int, convert(Float64, x))
+convert(::Type{Int}, x::BasicType{Val{:RealMPFR}}) = convert(Int, convert(BigFloat, x))
+convert(::Type{Int}, x::BasicComplexNumber) = imag(x) == 0 ? convert(Int, real(x)) : throw(InexactError())
+convert(::Type{Int}, x::BasicType) = convert(Int, convert(Float64, evalf(Basic(x), 53, true)))
+
+
+
+## BigInt
+convert(::Type{BigInt}, x::Basic) = convert(BigInt, BasicType(x))
+#function convert(::Type{BigInt}, x::BasicType{Val{:Integer}})
+convert(::Type{BigInt}, x::BasicType{Val{:Rational}}) = den(x) == 1 ? convert(BigInt, num(x)) : throw(InexactError())
+convert(::Type{BigInt}, x::BasicType{Val{:RealDouble}}) = convert(BigInt, convert(Float64, x))
+convert(::Type{BigInt}, x::BasicType{Val{:RealMPFR}}) = convert(BigInt, convert(BigFloat, x))
+convert(::Type{BigInt}, x::BasicComplexNumber) = imag(x) == 0 ? convert(BigInt, real(x)) : throw(InexactError())
+convert(::Type{BigInt}, x::BasicType) = throw(InexactError())
+
+## Float64
+convert(::Type{Float64}, x::Basic) = convert(Float64, BasicType(x))
+convert(::Type{Float64}, x::BasicType{Val{:Integer}}) = convert(Float64, convert(BigInt, x))
+##convert(::Type{Float64}, x::BasicType{Val{:RealDouble}}) =
+convert(::Type{Float64}, x::BasicType{Val{:RealMPFR}}) = convert(Float64, convert(BigFloat, x))
+convert(::Type{Float64}, x::BasicComplexNumber) = imag(x) == 0 ? convert(Float64, real(x)) : throw(InexactError())
+convert(::Type{Float64}, x::BasicType) = convert(Float64, evalf(Basic(x), 53, true))
+
+
+## BigFloat
+convert(::Type{BigFloat}, x::Basic) = convert(BigFloat, BasicType(x))
+convert(::Type{BigFloat}, x::BasicType{Val{:Integer}}) = BigFloat(convert(BigInt, x))
+convert(::Type{BigFloat}, x::BasicType{Val{:Rational}}) = BigFloat(convert(Rational{BigInt}, x))
+convert(::Type{BigFloat}, x::BasicType{Val{:RealDouble}}) = convert(BigFloat, convert(Float64, x))
+#convert(::Type{Float64}, x::BasicType{Val{:RealMPFR}}) 
+convert(::Type{BigFloat}, x::BasicComplexNumber) = imag(x) == 0 ? convert(BigFloat, real(x)) : throw(InexactError())
+convert(::Type{BigFloat}, x::BasicType) = throw(InexactError())
+
+## Rational
+Base.den(x::Basic) = den(BasicType(x))
+Base.den(x::BasicType{Val{:Integer}}) = Basic(1)
+Base.den(x::BasicType{Val{:Rational}}) = Basic(String(copy(split(SymEngine.toString(x), "/"))[2]))
+Base.den(x::BasicComplexNumber) = imag(x) == 0 ? den(real(x)) : throw(InexactError())
+Base.den(x::BasicType) = Basic(1)
+
+Base.num(x::Basic) = num(BasicType(x))
+Base.num(x::BasicType{Val{:Integer}}) = Basic(x)
+Base.num(x::BasicType{Val{:Rational}}) = Basic(String(copy(split(SymEngine.toString(x), "/"))[1]))
+Base.num(x::BasicComplexNumber) = imag(x) == 0 ? num(real(x)) : throw(InexactError())
+Base.num(x::BasicType) = throw(InexactError())
+
+convert{T}(::Type{Rational{T}}, x::Basic) = convert(Rational{T}, BasicType(x))
+convert{T}(::Type{Rational{T}}, x::BasicType{Val{:RealDouble}}) = convert(Rational, convert(Float64, x))
+convert{T}(::Type{Rational{T}}, x::BasicType) = Rational(convert(T, num(x)), convert(T, den(x)))
+
+
+## Complex
+Base.real(x::Basic) = real(SymEngine.BasicType(x))
+## BasicComplexNumber elsewhere
+Base.real(x::SymEngine.BasicType) = x
+
+Base.imag(x::Basic) = imag(SymEngine.BasicType(x))
+Base.imag(x::BasicType{Val{:Integer}}) = 0
+Base.imag(x::BasicType{Val{:RealDouble}}) = 0
+Base.imag(x::BasicType{Val{:RealMPFR}}) = 0
+Base.imag(x::BasicType{Val{:Rational}}) = 0
+Base.imag(x::SymEngine.BasicType) = x
+
+convert{T}(::Type{Complex{T}}, x::Basic) = complex(convert(T, real(x)), convert(T, imag(x)))
+
+
+##################################################
+# N
+"""
+
+Convert a SymEngine numeric value into a number
+
+"""
+N(a::Integer) = a
+N(a::Rational) = a
+N(a::Complex) = a
+N(b::Basic) = N(BasicType(b))
 
 function N(b::BasicType{Val{:Integer}})
     a = convert(BigInt, b)
@@ -90,17 +187,11 @@ function N(b::BasicType{Val{:Integer}})
     end
 end
 
-N(b::Basic) = N(BasicType(b))
+N(b::BasicType{Val{:Rational}}) = Rational(N(num(b)), N(den(b))) # TODO: Implement rational_get_mpq in cwrapper.h
 N(b::BasicType{Val{:RealDouble}}) = convert(Cdouble, b)
-# TODO: Implement rational_get_mpq in cwrapper.h
-N(b::BasicType{Val{:Rational}}) = eval(parse(replace(toString(b), "/", "//")))
 N(b::BasicType{Val{:RealMPFR}}) = convert(BigFloat, b)
-N(b::BasicComplexNumber) = complex(N(real(b)), N(imag(b)))
 
-## function N(b::BasicType{Val{:Rational}})
-##     println("XXX")
-## end
-## need to test for free_symbols, if none then we need to evaluate
+N(b::BasicComplexNumber) = complex(N(real(b)), N(imag(b)))
 function N(b::BasicType)
     b = convert(Basic, b)
     fs = free_symbols(b)
@@ -111,16 +202,27 @@ function N(b::BasicType)
 end
         
 
-N(a::Integer) = a
-N(a::Rational) = a
-N(a::Complex) = a
 
-function evalf(b::Basic, bits::Integer=53, real::Bool=false)
-    c = Basic()
-    status = ccall((:basic_evalf, libsymengine), Cint, (Ptr{Basic}, Ptr{Basic}, Culong, Cint), &c, &b, Culong(bits), Int(real))
-    if status == 0
-        return c
-    else
-        throw(ArgumentError("libsymengine has to be compiled with MPFR and MPC for eval with precision greater than 53."))
-    end
-end
+## For generic programming in Julia
+Base.convert{T <: Real}(::Type{T}, x::Basic) = convert(T, N(x))
+Base.float(x::Basic) = float(N(x))
+
+# trunc, flooor, ceil, round, rem, mod, cld, fld, 
+isfinite(x::Basic) = x-x == 0
+isnan(x::Basic) = isnan(N(x))
+isinf(x::Basic) = !isnan(x) & !isfinite(x)
+isless(x::Basic, y::Basic) = isless(N(x), N(y))
+
+
+## These are seriously hacky.
+trunc(x::Basic, args...) = Basic(trunc(Float64(x), args...))  
+trunc{T <: Integer}(::Type{T},x::Basic, args...) = convert(T, trunc(x,args...))
+
+ceil(x::Basic) = Basic(ceil(Float64(x)))
+ceil{T <: Integer}(::Type{T},x::Basic) = convert(T, ceil(x))
+
+floor(x::Basic) = Basic(floor(Float64(x)))
+floor{T <: Integer}(::Type{T},x::Basic) = convert(T, floor(x))
+
+round(x::Basic) = Basic(round(Float64(x)))
+round{T <: Integer}(::Type{T},x::Basic) = convert(T, round(x))

--- a/src/types.jl
+++ b/src/types.jl
@@ -169,6 +169,8 @@ Basic(x::BasicType) = x.x
 
 BasicType(val::Basic) =  BasicType{Val{get_symengine_class(val)}}(val)
 convert{T}(::Type{BasicType{T}}, val::Basic) = BasicType{Val{get_symengine_class(val)}}(val)
+# Needed for julia v0.4.7
+convert{T<:BasicType}(::Type{T}, x::Basic) = BasicType(x)
 
 
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -161,6 +161,8 @@ type BasicType{T} <: Number
     x::Basic
 end
 
+convert(::Type{Basic}, x::Basic) = x
+
 SymbolicType = Union{Basic, BasicType}
 convert(::Type{Basic}, x::BasicType) = x.x
 Basic(x::BasicType) = x.x

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,7 +130,21 @@ x,y,z = symbols("x y z")
 @test length(SymEngine.free_symbols([x*y, y,z])) == 3
 
 
-## check that symengine expressions can be used as functions 
+## check that callable symengine expressions can be used as functions for duck-typed functions
 @vars x
 a,err = quadgk(x^2, 0, 1)
 @test abs(a - 1/3) <= err
+
+## Check conversions SymEngine -> Julia
+z,flt, rat, ima, cplx = btypes = [Basic(1), Basic(1.23), Basic(3//5), Basic(2im), Basic(1 + 2im)]
+
+@test Int(z) == 1
+@test BigInt(z) == 1
+@test Float64(flt) ≈ 1.23
+@test Real(flt) ≈ 1.23
+@test convert(Rational{Int}, rat) == 3//5
+@test convert(Complex{Int}, ima) == 2im
+@test convert(Complex{Int}, cplx) == 1 + 2im
+
+@test_throws InexactError convert(Int, flt)
+@test_throws InexactError convert(Int, rat)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -128,3 +128,9 @@ A = [x 2; x 1]
 ## check that unique work (hash)
 x,y,z = symbols("x y z")
 @test length(SymEngine.free_symbols([x*y, y,z])) == 3
+
+
+## check that symengine expressions can be used as functions 
+@vars x
+a,err = quadgk(x^2, 0, 1)
+@test abs(a - 1/3) <= err


### PR DESCRIPTION
Fixes #54 

* it makes expressions callable
* it adds some functions for generic programming to Basic objects (isnan, isinf, ceil, float, ...). These could use some support at the cwrapper level.
* it adds conversion methods leveraging N
* it replaces `lambdify` with `evalf` in the catch-all method for `N`.
* it adds a few tests