### PR TITLE
v0.6 updates

### DIFF
--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -3,8 +3,9 @@ __precompile__()
 module SymEngine
 
 import Base: show, convert, real, imag
-
-using Compat: String, unsafe_string, @compat
+using Compat: String, unsafe_string, @compat, denominator, numerator
+VERSION >= v"0.6.0-dev" && import Base.numerator, Base.denominator
+VERSION < v"0.6.0-dev" && import Compat.numerator, Compat.denominator
 
 export Basic, symbols, @vars
 export free_symbols, get_args

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -3,9 +3,7 @@ __precompile__()
 module SymEngine
 
 import Base: show, convert, real, imag
-using Compat: String, unsafe_string, @compat, denominator, numerator
-VERSION >= v"0.6.0-dev" && import Base.numerator, Base.denominator
-VERSION < v"0.6.0-dev" && import Compat.numerator, Compat.denominator
+import Compat: String, unsafe_string, @compat, denominator, numerator
 
 export Basic, symbols, @vars
 export free_symbols, get_args

--- a/src/types.jl
+++ b/src/types.jl
@@ -80,7 +80,7 @@ else
 end
 convert(::Type{Basic}, x::Union{Float16, Float32, Float64}) = Basic(convert(Cdouble, x))
 convert(::Type{Basic}, x::Integer) = Basic(BigInt(x))
-convert(::Type{Basic}, x::Rational) = Basic(num(x)) / Basic(den(x))
+convert(::Type{Basic}, x::Rational) = Basic(numerator(x)) / Basic(denominator(x))
 convert(::Type{Basic}, x::Complex) = Basic(real(x)) + Basic(imag(x)) * IM
 
 Base.promote_rule{S<:Number}(::Type{Basic}, ::Type{S} ) = Basic


### PR DESCRIPTION
Fixes #61 

This makes adjustments for v0.6-dev changes:

* lambdify(ex)(val) is currently broken, this adds a workaround

* `quadgk` was moved to an external package. This replaces "duck typing" test with  simple newton's method algorithm. This doesn't test programming to a generic interface as well.

* den/num deprecation fixes. I condition of `VERSION >= v"0.6.0-dev", but this could be tighter if it seems to matter.