### PR TITLE
Use Binaries instead of Conda in windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,12 @@ environment:
   matrix:
   - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
   - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIAVERSION: "julialang/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+matrix:
+  allow_failures:
   - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
   - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,17 +4,22 @@ using Conda
 @BinDeps.setup
 
 libsymengine = library_dependency("libsymengine", aliases=["libsymengine", "symengine"])
-env = Symbol(abspath(dirname(@__FILE__), "usr"))
-
-Conda.add_channel("conda-forge", env)
-Conda.add_channel("symengine", env)
 
 if is_windows()
-    # SymEngine can only be installed to a python 3.5 environment
-    Conda.add("python=3.5", env)
+    path = abspath(dirname(@__FILE__), "usr")
+    isdir(path) || mkdir(path)
+    if WORD_SIZE == 64
+        url = "https://github.com/symengine/symengine/releases/download/v0.2.0/binaries-msvc-x86_64.tar.bz2"
+    else
+        url = "https://github.com/symengine/symengine/releases/download/v0.2.0/binaries-msvc-x86.tar.bz2"
+    end
+    provides(Binaries, URI(url), libsymengine, unpacked_dir="$path/bin")
+else
+    env = Symbol(abspath(dirname(@__FILE__), "usr"))
+    Conda.add_channel("conda-forge", env)
+    Conda.add_channel("symengine", env)
+    provides(Conda.EnvManager{env}, "symengine==0.2.0", [libsymengine])
 end
-
-provides(Conda.EnvManager{env}, "symengine==0.2.0", [libsymengine])
 
 @BinDeps.install Dict([(:libsymengine, :libsymengine)])
 


### PR DESCRIPTION
@Datseris, @ChrisRackauckas, @musm, what do you think about this?
This would remove the dependency on Conda for windows.
I installed symengine through conda, removed unnecessary things and archived the folder. Now it's downloading a 5MB archive for windows.