### PR TITLE
V0.7 warnings

### DIFF
--- a/src/dense-matrix.jl
+++ b/src/dense-matrix.jl
@@ -174,7 +174,7 @@ function LinearAlgebra.lu(a::CDenseMatrix)
     l, u = dense_matrix_LU(a)
     convert(Matrix, l), convert(Matrix, u), Matrix{Basic}(LinearAlgebra.I, size(l)[1], size(l)[1])
 end
-LinearAlgebra.lu(a::Array{T,2}) where {T <: Basic} = LinearAlgebra.lu(convert(CDenseMatrix, a))
+
 
 
 # solve using LU_solve

--- a/src/dense-matrix.jl
+++ b/src/dense-matrix.jl
@@ -175,6 +175,9 @@ function LinearAlgebra.lu(a::CDenseMatrix)
     convert(Matrix, l), convert(Matrix, u), Matrix{Basic}(LinearAlgebra.I, size(l)[1], size(l)[1])
 end
 
+if VERSION < VersionNumber("0.7.0-DEV")
+    LinearAlgebra.lu(a::Array{T,2}) where {T <: Basic} = LinearAlgebra.lu(convert(CDenseMatrix, a))
+end
 
 
 # solve using LU_solve

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -146,10 +146,10 @@ denominator(x::SymbolicType) = as_numer_denom(x)[2]
 numerator(x::SymbolicType)   = as_numer_denom(x)[1]
 
 ## Complex
-real(x::Basic) = real(SymEngine.BasicType(x))
+real(x::Basic) = Basic(real(SymEngine.BasicType(x)))
 real(x::SymEngine.BasicType) = x
 
-imag(x::Basic) = imag(SymEngine.BasicType(x))
+imag(x::Basic) = Basic(imag(SymEngine.BasicType(x)))
 imag(x::BasicType{Val{:Integer}}) = Basic(0)
 imag(x::BasicType{Val{:RealDouble}}) = Basic(0)
 imag(x::BasicType{Val{:RealMPFR}}) = Basic(0)

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -165,6 +165,11 @@ convert(::Type{Number}, x::Basic)            = x
 convert(::Type{T}, x::Basic) where {T <: Real}      = convert(T, N(x))
 convert(::Type{Complex{T}}, x::Basic) where {T <: Real}    = convert(Complex{T}, N(x))
 
+# Constructors no longer fall back to `convert` methods
+Base.Int64(x::Basic) = convert(Int64, x)
+Base.Float64(x::Basic) = convert(Float64, x)
+Base.BigInt(x::Basic) = convert(BigInt, x)
+Base.Real(x::Basic) = convert(Real, x)
 
 ## For generic programming in Julia
 float(x::Basic) = float(N(x))

--- a/test/test-dense-matrix.jl
+++ b/test/test-dense-matrix.jl
@@ -31,7 +31,10 @@ M[1,1] = x
 @test inv(M) - inv(A) == zeros(Basic, 3,3)
 
 # factorizations
-@test lu(M) == lu(A)
+L1, U1 = lu(M)
+L2, U2, P2 = lu(A)
+@test iszero(expand.(L1 - L2))
+@test iszero(expand.(U1 - U2))
 
 A = [x 1 2; 0 x 4; 0 0 x]
 b = [1, 2, 3]


### PR DESCRIPTION
There was an error with `det` when running `test` under v0.7-alpha. This cleans that up by removing an `lu` method for `Array{Basic,2}`. It also addresses some warnings arising from constructors not defaulting to `convert` methods (this latter could be done more systematically?)