### PR TITLE
Fix: malformed "import" statement

### DIFF
--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -56,7 +56,7 @@ for (meth, libnm, modu) in [
                       (:eta,:dirichlet_eta,:SpecialFunctions),
                       (:zeta,:zeta,:SpecialFunctions),
                       ]
-    eval(Expr(:import, modu, meth))
+    eval(:(import $modu.$meth))
     IMPLEMENT_ONE_ARG_FUNC(:($modu.$meth), libnm)
 end
 Base.abs2(x::SymEngine.Basic) = abs(x)^2
@@ -78,7 +78,7 @@ end
 Base.cbrt(a::SymbolicType) = a^(1//3)
 
 for (meth, fn) in [(:sind, :sin), (:cosd, :cos), (:tand, :tan), (:secd, :sec), (:cscd, :csc), (:cotd, :cot)]
-    eval(Expr(:import, :Base, meth))
+    eval(:(import Base.$meth))
     @eval begin
         $(meth)(a::SymbolicType) = $(fn)(a*PI/180)
     end
@@ -91,7 +91,7 @@ for (meth, libnm) in [(:gcd, :gcd),
                       (:div, :quotient),
                       (:mod, :mod_f),
                       ]
-    eval(Expr(:import, :Base, meth))
+    eval(:(import Base.$meth))
     IMPLEMENT_TWO_ARG_FUNC(:(Base.$meth), libnm, lib=:ntheory_)
 end
 


### PR DESCRIPTION
I think the recent failures with Julia master https://travis-ci.org/symengine/SymEngine.jl/jobs/488003068#L587 are due to https://github.com/JuliaLang/julia/pull/30799.

The AST data structure for the import statement is:

```
julia> dump(:(import Base.sin))
Expr
  head: Symbol import
  args: Array{Any}((1,))
    1: Expr
      head: Symbol .
      args: Array{Any}((2,))
        1: Symbol Base
        2: Symbol sin
```

(since Julia 0.7, I think).

So using

```
julia> Expr(:import, :Base, :sin)
:($(Expr(:import, :Base, :sin)))
```

is incorrect and it should be

```
julia> Expr(:import, Expr(:., :Base, :sin))
:(import Base.sin)
```

But I suggest to use `:(import $modu.$meth)` rather than writing the AST data structure directly.
