### PR TITLE
Fix hash function (use 2 arg form)

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -279,7 +279,10 @@ function get_args(ex::Basic)
 end
 
 ## so that Dicts will work
-Base.hash(ex::Basic) = ccall((:basic_hash, libsymengine), UInt, (Ref{Basic}, ), ex)
+basic_hash(ex::Basic) = ccall((:basic_hash, libsymengine), UInt, (Ref{Basic}, ), ex)
+# similar definition as in Base for general objects
+Base.hash(ex::Basic, h::UInt) = Base.hash_uint(3h - basic_hash(ex))
+Base.hash(ex::BasicType, h::UInt) = hash(Basic(ex), h)
 
 function coeff(b::Basic, x::Basic, n::Basic)
     c = Basic()


### PR DESCRIPTION
The documentation advises to implement the two argument form of `Base.hash`. Otherwise it can still happen that hashing happens based on the object id (which we don't want to happen).