### PR TITLE
Tests of infinities (zoo & oo) as arguments to functions (issue #228)

### DIFF
--- a/src/exceptions.jl
+++ b/src/exceptions.jl
@@ -14,7 +14,7 @@ function get_error(error_code::Cuint, str=nothing)
     elseif error_code == 3
         return ErrorException("Not implemented SymEngine feature")
     elseif error_code == 4
-        return DomainError()
+        return DomainError(str)
     elseif error_code == 5
         return Meta.ParseError(str)
     else

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -5,7 +5,7 @@ function IMPLEMENT_ONE_ARG_FUNC(meth, symnm; lib=:basic_)
         function ($meth)(b::SymbolicType)
             a = Basic()
             err_code = ccall(($(string(lib,symnm)), libsymengine), Cuint, (Ref{Basic}, Ref{Basic}), a, b)
-            throw_if_error(err_code)
+            throw_if_error(err_code, $meth)
             return a
         end
     end
@@ -17,7 +17,7 @@ function IMPLEMENT_TWO_ARG_FUNC(meth, symnm; lib=:basic_)
             a = Basic()
             b1, b2 = promote(b1, b2)
             err_code = ccall(($(string(lib,symnm)), libsymengine), Cuint, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
-            throw_if_error(err_code)
+            throw_if_error(err_code, $meth)
             return a
         end
     end

--- a/src/mathfuns.jl
+++ b/src/mathfuns.jl
@@ -4,7 +4,8 @@ function IMPLEMENT_ONE_ARG_FUNC(meth, symnm; lib=:basic_)
      @eval begin
         function ($meth)(b::SymbolicType)
             a = Basic()
-            ccall(($(string(lib,symnm)), libsymengine), Nothing, (Ref{Basic}, Ref{Basic}), a, b)
+            err_code = ccall(($(string(lib,symnm)), libsymengine), Cuint, (Ref{Basic}, Ref{Basic}), a, b)
+            throw_if_error(err_code)
             return a
         end
     end
@@ -15,7 +16,8 @@ function IMPLEMENT_TWO_ARG_FUNC(meth, symnm; lib=:basic_)
         function ($meth)(b1::SymbolicType, b2::Number)
             a = Basic()
             b1, b2 = promote(b1, b2)
-            ccall(($(string(lib,symnm)), libsymengine), Nothing, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
+            err_code = ccall(($(string(lib,symnm)), libsymengine), Cuint, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
+            throw_if_error(err_code)
             return a
         end
     end

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -13,7 +13,8 @@ for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div),
     @eval begin
         function ($op)(b1::Basic, b2::Basic)
             a = Basic()
-            ccall($tup, Nothing, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
+            err_code = ccall($tup, Cuint, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
+            throw_if_error(err_code)
             return a
         end
         ($op)(b1::BasicType, b2::BasicType) = ($op)(Basic(b1), Basic(b2))

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -14,7 +14,7 @@ for (op, libnm) in ((:+, :add), (:-, :sub), (:*, :mul), (:/, :div), (://, :div),
         function ($op)(b1::Basic, b2::Basic)
             a = Basic()
             err_code = ccall($tup, Cuint, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
-            throw_if_error(err_code)
+            throw_if_error(err_code, $(string(libnm)))
             return a
         end
         ($op)(b1::BasicType, b2::BasicType) = ($op)(Basic(b1), Basic(b2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -240,3 +240,8 @@ if SymEngine.libversion >= VersionNumber("0.4.0")
         @test coeff(expr, x, Basic(0)) == y^3 + 1
     end
 end
+
+# Check that infinities are handled correctly
+@test_throws DomainError exp(zoo)
+@test_throws DomainError sin(zoo)
+@test_throws DomainError sin(oo)


### PR DESCRIPTION
For (not necessarily all) functions having `SymEngine.zoo` or
`SymEngine.oo` as an argument a `DomainError` should be thrown
(similarity to how `sin(Inf)` does). These tests includes some examples
where `DomainError`s should be thrown.