### PR TITLE
implement fallback `conj` to fix `dot`

### DIFF
--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -151,9 +151,9 @@ function N(b::BasicType)
     out = evalf(b)
     imag(out) == Basic(0.0) ? real(out) : out
 end
-        
 
-##  Conversions SymEngine -> Julia 
+
+##  Conversions SymEngine -> Julia
 function as_numer_denom(x::Basic)
     a, b = Basic(), Basic()
     ccall((:basic_as_numer_denom, libsymengine), Nothing, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b, x)
@@ -174,6 +174,11 @@ imag(x::BasicType{Val{:RealDouble}}) = Basic(0)
 imag(x::BasicType{Val{:RealMPFR}}) = Basic(0)
 imag(x::BasicType{Val{:Rational}}) = Basic(0)
 imag(x::SymEngine.BasicType) = throw(InexactError())
+
+# Because of the definitions above, `real(x) == x` for `x::Basic`
+# such as `x = symbols("x")`. Thus, it is consistent to define the
+# fallback
+Base.conj(x::Basic) = x
 
 ## define convert(T, x) methods leveraging N()
 convert(::Type{Float64}, x::Basic)           = convert(Float64, N(evalf(x, 53, true)))
@@ -203,7 +208,7 @@ isless(x::Basic, y::Basic) = isless(N(x), N(y))
 
 
 ## These should have support in symengine-wrapper, but currently don't
-trunc(x::Basic, args...) = Basic(trunc(N(x), args...))  
+trunc(x::Basic, args...) = Basic(trunc(N(x), args...))
 trunc(::Type{T},x::Basic, args...) where {T <: Integer} = convert(T, trunc(x,args...))
 
 ceil(x::Basic) = Basic(ceil(N(x)))

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -178,7 +178,7 @@ imag(x::SymEngine.BasicType) = throw(InexactError())
 # Because of the definitions above, `real(x) == x` for `x::Basic`
 # such as `x = symbols("x")`. Thus, it is consistent to define the
 # fallback
-Base.conj(x::Basic) = x
+Base.conj(x::Basic) = 2 * real(x) - x
 
 ## define convert(T, x) methods leveraging N()
 convert(::Type{Float64}, x::Basic)           = convert(Float64, N(evalf(x, 53, true)))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -246,3 +246,12 @@ end
 @test_throws DomainError sin(zoo)
 @test_throws DomainError sin(oo)
 @test_throws DomainError subs(sin(log(y - y/x)), x => 1)
+
+# Some basic checks for complex numbers
+@testset "Complex numbers" begin
+    for T in (Int, Float64, BigFloat)
+        j = one(T) * IM
+        @test j == imag(j) * IM
+        @test conj(j) == -j
+    end
+end

--- a/test/test-dense-matrix.jl
+++ b/test/test-dense-matrix.jl
@@ -1,9 +1,9 @@
 using Test
 using SymEngine
-import LinearAlgebra: lu, det, zeros
+import LinearAlgebra: lu, det, zeros, dot
 CDenseMatrix = SymEngine.CDenseMatrix
 
-@vars x
+@vars x y
 
 # constructors
 A = [x 1 2; 3 x 4; 5 6 x]
@@ -44,3 +44,6 @@ out = M \ b
 
 @test SymEngine.dense_matrix_eye(2,2,0) == Basic[1 0; 0 1]
 
+# dot product
+@test dot(x, x) == x^2
+@test dot([1, x, 0], [y, -2, 1]) == y - 2x


### PR DESCRIPTION
Right now on `master`,
```julia
julia> using SymEngine

julia> @vars x
(x,)

julia> using LinearAlgebra

julia> dot([1, x], [x, 0])
ERROR: MethodError: no method matching conj(::Basic)
```

`real` etc. is not really working properly right now, see #110 and
```julia
julia> using SymEngine

julia> @vars x
(x,)

julia> x == real(x)
true

julia> iszero(x - real(x))
true
```

Thus, this implemented fallback `conj(x) = x` is in accordance with the sensible definition
```julia
conj(x) = real(x) - (x - real(x))
```
for complex numbers.

I would like to get this merged into a new release of SymEngine.jl to allow further working with `dot` products of symbolic variables (which seem to be mostly real). Extensions to a proper support of complex numbers and further fixes should be discussed in #110 etc.

This fixes a problem reported by @ketch (`dot` product involving `SymEngine.Basic` variables representing real numbers).