### PR TITLE
implement fallback for `//`

### DIFF
--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -27,6 +27,12 @@ end
 -(b::SymbolicType) = 0 - b
 \(b1::SymbolicType, b2::SymbolicType) = b2 / b1
 
+# In contrast to other standard operations such as `+`, `*`, `-`, and `/`,
+# Julia doesn't implement a general fallback of `//` for `Number`s promoting
+# the input arguments. Thus, we implement this here explicitly.
+Base.:(//)(b1::SymbolicType, b2::Number) = //(promote(b1, b2)...)
+Base.:(//)(b1::Number, b2::SymbolicType) = //(promote(b1, b2)...)
+
 
 ## ## constants
 Base.zero(x::Basic) = Basic(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -42,6 +42,10 @@ println()
 show(b)
 println()
 
+@test 1 // x == 1 / x
+@test x // 2 == (1//2) * x
+@test x // y == x / y
+
 
 ## mathfuns
 @test abs(Basic(-1)) == 1


### PR DESCRIPTION
In contrast to other standard operations such as `+`, `*`, `-`, and `/`, Julia doesn't implement a general fallback of `//` for `Number`s promoting the input arguments. Thus, I have added these fallback definitions involving `SymbolicType`s here.

Closes #232