### PR TITLE
Effective multiplication of n multipliers

### DIFF
--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -54,7 +54,7 @@ end
 function prod(v::CVecBasic)
     a = Basic()
     err_code = ccall((:basic_mul_vec, libsymengine), Cuint, (Ref{Basic}, Ptr{Cvoid}), a, v.ptr)
-    throw_if_error(err_code, "add_mul")
+    throw_if_error(err_code, "mul_vec")
     return a
 end
 

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -67,6 +67,8 @@ end
 *(b1, b2::Basic, b3, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
 *(b1, b2, b3::Basic, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
 
+
+
 ## ## constants
 Base.zero(x::Basic) = Basic(0)
 Base.zero(::Type{T}) where {T<:Basic} = Basic(0)

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -68,7 +68,6 @@ end
 *(b1, b2, b3::Basic, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
 
 
-
 ## ## constants
 Base.zero(x::Basic) = Basic(0)
 Base.zero(::Type{T}) where {T<:Basic} = Basic(0)

--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -1,4 +1,4 @@
-import Base: +, -, ^, /, //, \, *, ==, sum
+import Base: +, -, ^, /, //, \, *, ==, sum, prod
 
 ## equality
 function ==(b1::SymbolicType, b2::SymbolicType)
@@ -50,6 +50,22 @@ end
 +(b1, b2::Basic, b3, bs...) = +(Basic(b1), Basic(b2), Basic(b3), bs...)
 +(b1, b2, b3::Basic, bs...) = +(Basic(b1), Basic(b2), Basic(b3), bs...)
 
+
+function prod(v::CVecBasic)
+    a = Basic()
+    err_code = ccall((:basic_mul_vec, libsymengine), Cuint, (Ref{Basic}, Ptr{Cvoid}), a, v.ptr)
+    throw_if_error(err_code, "add_mul")
+    return a
+end
+
+*(b1::Basic, b2::Basic, b3::Basic, bs...) = prod(convert(CVecBasic, [b1, b2, b3, bs...]))
+*(b1::Basic, b2::Basic, b3, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
+*(b1, b2::Basic, b3::Basic, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
+*(b1::Basic, b2, b3::Basic, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
+
+*(b1::Basic, b2, b3, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
+*(b1, b2::Basic, b3, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
+*(b1, b2, b3::Basic, bs...) = *(Basic(b1), Basic(b2), Basic(b3), bs...)
 
 ## ## constants
 Base.zero(x::Basic) = Basic(0)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,6 +33,14 @@ c = sum(convert(SymEngine.CVecBasic, [x, x, 1]))
 @test x + 1 + 1 == x + 2
 @test 1 + x + 1 == x + 2
 
+c = prod(convert(SymEngine.CVecBasic, [x, x, 2]))
+@test c == 2*x^2
+@test x * x * 2 == 2*x^2
+@test x * 2 * 3 == 6 * x
+@test 2 * 3 * x == 6 * x
+@test 2 * x * 3 == 6 * x
+
+
 c = x ^ 5
 @test diff(c, x) == 5 * x ^ 4
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ c = prod(convert(SymEngine.CVecBasic, [x, x, 2]))
 @test x * 2 * 3 == 6 * x
 @test 2 * 3 * x == 6 * x
 @test 2 * x * 3 == 6 * x
-
+@test 3 * 2 * x == 6 * x
 
 c = x ^ 5
 @test diff(c, x) == 5 * x ^ 4


### PR DESCRIPTION
Adds optimized version of array multiplication. Currently, code similar to `a1*a2*a3*a4` will use `afoldl` to evaluate product.

A PR was created to add C wrapper of array product (https://github.com/symengine/symengine/pull/1880). If it will be merged, then this PR could also be merged.