### PR TITLE
Serialization and deserialization implemented

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+Serialization = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 SymEngine_jll = "3428059b-622b-5399-b16f-d347a77089a4"
 

--- a/src/SymEngine.jl
+++ b/src/SymEngine.jl
@@ -4,6 +4,7 @@ using SymEngine_jll
 
 import Base: show, convert, real, imag, MathConstants.γ, MathConstants.e, MathConstants.φ, MathConstants.catalan, invokelatest
 import Compat: String, unsafe_string, @compat, denominator, numerator, Cvoid, Nothing, finalizer, reduce, mapreduce
+import Serialization
 import LinearAlgebra, Libdl
 
 export Basic, symbols, @vars, @funs, SymFunction

--- a/src/types.jl
+++ b/src/types.jl
@@ -300,6 +300,6 @@ function Serialization.deserialize(s::Serialization.AbstractSerializer, ::Type{B
 	a = Basic()
 	res = ccall((:basic_loads, libsymengine), 
 		Cuint, (Ref{Basic}, Ptr{Int8}, UInt64), a, ser_str, length(ser_str))
-	throw_if_error(res, ser_str)
+	throw_if_error(res)
 	return a
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SymEngine
 using Compat
 using Test
+using Serialization
 import Base: MathConstants.γ, MathConstants.e, MathConstants.φ, MathConstants.catalan
 
 include("test-dense-matrix.jl")
@@ -273,3 +274,20 @@ end
 
 @test round(Basic(3.14)) == 3.0
 @test round(Basic(3.14); digits=1) == 3.1
+
+function is_serialization_correct(expr :: Basic)
+	iobuf = IOBuffer()
+	serialize(iobuf, expr)
+	seek(iobuf, 0)
+	deserialized = deserialize(iobuf)
+	close(iobuf)
+	return expr == deserialized
+end
+
+@vars x y
+@testset "Serialization and deserialization" begin
+	@test is_serialization_correct(Basic(1.0))
+	@test is_serialization_correct(Basic(pi))
+	@test is_serialization_correct(Basic(x + y))
+	@test is_serialization_correct(Basic(sin(cos(pi*x + y)) + y^2))
+end


### PR DESCRIPTION
Allows to serialize and deserialize SymEngine expressions. This makes posssible saving/loading, parallel and distributed computing  with SymEngine entities. May fix #242 and #198.