### PR TITLE
Fixed serialization issue

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -290,4 +290,13 @@ end
 	@test is_serialization_correct(Basic(pi))
 	@test is_serialization_correct(Basic(x + y))
 	@test is_serialization_correct(Basic(sin(cos(pi*x + y)) + y^2))
+
+	# Complex type test
+	iobuf = IOBuffer()
+	data = [x+y, x+y]
+	serialize(iobuf, data)
+	seek(iobuf, 0)
+	deserialized = deserialize(iobuf)
+	close(iobuf)
+	@test deserialized == data
 end


### PR DESCRIPTION
Fixes #255

I'm not sure, but it seems that the issue was with string conversion. Serialized data is **not** NUL-terminated and `serialize` function was writing data using strings. `unsafe_string` with specified length wrote all the data correctly but `read(io, String)` in deserialization function had problems with parsing this strings.

Current implementation manipulates data with Int8 arrays and works without problems.