### PR TITLE
fix lu return type

### DIFF
--- a/src/dense-matrix.jl
+++ b/src/dense-matrix.jl
@@ -175,7 +175,10 @@ Also: lufact(a, val{:false}) for non-pivoting lu factorization
 """
 function LinearAlgebra.lu(a::CDenseMatrix)
     l, u = dense_matrix_LU(a)
-    convert(Matrix, l), convert(Matrix, u), Matrix{Basic}(LinearAlgebra.I, size(l)[1], size(l)[1])
+    L, U = convert(Matrix, l), convert(Matrix, u)
+    n = size(L, 1)
+    L[1:n+1:end] .-= one(eltype(L))
+    return LinearAlgebra.LU(L + U, collect(1:n), 0)
 end
 LinearAlgebra.lu(a::Array{Basic,2}) = LinearAlgebra.lu(CDenseMatrix(a))
 

--- a/test/test-dense-matrix.jl
+++ b/test/test-dense-matrix.jl
@@ -47,3 +47,12 @@ out = M \ b
 # dot product
 @test dot(x, x) == x^2
 @test dot([1, x, 0], [y, -2, 1]) == y - 2x
+
+@testset "dense matrix" begin
+    @vars a b c d x y
+    A = [a b; c d]
+    b = [x, y]
+    res = A \ b
+    @test res == [(x - b*(y - c*x/a)/(d - b*c/a))/a
+           (y - c*x/a)/(d - b*c/a)]
+end

--- a/test/test-dense-matrix.jl
+++ b/test/test-dense-matrix.jl
@@ -51,8 +51,8 @@ out = M \ b
 @testset "dense matrix" begin
     @vars a b c d x y
     A = [a b; c d]
-    b = [x, y]
-    res = A \ b
-    @test res == [(x - b*(y - c*x/a)/(d - b*c/a))/a
+    B = [x, y]
+    res = A \ B
+    @test res == [(x - b*(y - c*x/a)/(d - b*c/a))/a,
            (y - c*x/a)/(d - b*c/a)]
 end


### PR DESCRIPTION
### Before the fix
```julia
julia> @vars a b c d x y
(a, b, c, d, x, y)

julia> A = [a b; c d]
2×2 Matrix{Basic}:
 a  b
 c  d

julia> b = [x, y]
2-element Vector{Basic}:
 x
 y

julia> res = A \ b
ERROR: MethodError: no method matching adjoint(::Tuple{Matrix{Basic}, Matrix{Basic}, Matrix{Basic}})
Closest candidates are:
  adjoint(::Union{LinearAlgebra.QR, LinearAlgebra.QRCompactWY, LinearAlgebra.QRPivoted}) at ~/.julia/juliaup/julia-1.8.4+0.x64.linux.gnu/share/julia/stdlib/v1.8/LinearAlgebra/src/qr.jl:517
  adjoint(::Union{LinearAlgebra.Cholesky, LinearAlgebra.CholeskyPivoted}) at ~/.julia/juliaup/julia-1.8.4+0.x64.linux.gnu/share/julia/stdlib/v1.8/LinearAlgebra/src/cholesky.jl:558
  adjoint(::LinearAlgebra.LQ) at ~/.julia/juliaup/julia-1.8.4+0.x64.linux.gnu/share/julia/stdlib/v1.8/LinearAlgebra/src/lq.jl:138
  ...
Stacktrace:
 [1] \(x::Tuple{Matrix{Basic}, Matrix{Basic}, Matrix{Basic}}, y::Vector{Basic})
   @ Base ./operators.jl:629
 [2] \(A::Matrix{Basic}, B::Vector{Basic})
   @ LinearAlgebra ~/.julia/juliaup/julia-1.8.4+0.x64.linux.gnu/share/julia/stdlib/v1.8/LinearAlgebra/src/generic.jl:1110
 [3] top-level scope
   @ REPL[24]:1
```

### After the fix
```julia
julia> res = A \ b
2-element Vector{Basic}:
 (x - b*(y - c*x/a)/(d - b*c/a))/a
           (y - c*x/a)/(d - b*c/a)
```