### PR TITLE
use more generic types

### DIFF
--- a/src/ctypes.jl
+++ b/src/ctypes.jl
@@ -86,7 +86,7 @@ function CMapBasicBasic()
     z
 end
 
-function CMapBasicBasic(dict::Dict)
+function CMapBasicBasic(dict::AbstractDict)
     c = CMapBasicBasic()
     for (key, value) in dict
         c[Basic(key)] = Basic(value)
@@ -118,7 +118,7 @@ function Base.setindex!(s::CMapBasicBasic, v::Basic, k::Basic)
     ccall((:mapbasicbasic_insert, libsymengine), Nothing, (Ptr{Cvoid}, Ref{Basic}, Ref{Basic}), s.ptr, k, v)
 end
 
-Base.convert(::Type{CMapBasicBasic}, x::Dict{Any, Any}) = CMapBasicBasic(x)
+Base.convert(::Type{CMapBasicBasic}, x::AbstractDict) = CMapBasicBasic(x)
 
 ## Dense matrix
 

--- a/src/subs.jl
+++ b/src/subs.jl
@@ -29,7 +29,7 @@ function subs(ex::T, d::CMapBasicBasic) where T<:SymbolicType
     return s
 end
 
-subs(ex::T, d::Dict) where {T<:SymbolicType} = subs(ex, CMapBasicBasic(d))
+subs(ex::T, d::AbstractDict) where {T<:SymbolicType} = subs(ex, CMapBasicBasic(d))
 subs(ex::T, y::Tuple{S, Any}) where {T <: SymbolicType, S<:SymbolicType} = subs(ex, y[1], y[2])
 subs(ex::T, y::Tuple{S, Any}, args...) where {T <: SymbolicType, S<:SymbolicType} = subs(subs(ex, y), args...)
 subs(ex::T, d::Pair...) where {T <: SymbolicType} = subs(ex, [(p.first, p.second) for p in d]...)
@@ -41,7 +41,7 @@ function (ex::Basic)(args...)
   xs = free_symbols(ex)
   subs(ex, collect(zip(xs, args))...)
 end
-(ex::Basic)(x::Dict) = subs(ex, x)
+(ex::Basic)(x::AbstractDict) = subs(ex, x)
 (ex::Basic)(x::Pair...) = subs(ex, x...)
 
 


### PR DESCRIPTION
I have an application where I want to use an `OrderedDict` (from `OrderedCollections.jl`) with `subs`, but some methods are too strictly typed. This PR widens the type from `Dict` to the more generic `AbstractDict` for the relevant methods.

Update: Turns out that I did not need this for my app, see below, but I think the changes are still useful.

---

My initial motivation for using an `OrderedDict` instead of just calling `subs(eq, x => y)` repeatedly and in the right order was that I thought the former is faster.
But it turned out that the benchmark I did was wrong, because of the following
```jl
a, b, c = symbols("a, b, c")
subs(a+b, a=>b, b=>c) # = 2 c
subs(a+b, Dict(a=>b,b=>c)) # = b + c
```
I think the issue is that the first version is translated to `subs(subs(a+b, a=>b), b=>c)`, whereas the dict version somehow performs both substitutions at the same time.

