### PR TITLE
handle conversion of NAN, oo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SymEngine"
 uuid = "123dc426-2d89-5057-bbad-38513e3affd8"
-version = "0.11.0"
+version = "0.11.1"
 
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"

--- a/src/numerics.jl
+++ b/src/numerics.jl
@@ -4,6 +4,7 @@ import Base: trunc, ceil, floor, round
 
 
 function evalf(b::Basic, bits::Integer=53, real::Bool=false)
+    !isfinite(b) && return b
     c = Basic()
     bits > 53 && real && (have_mpfr || throw(ArgumentError("libsymengine has to be compiled with MPFR for this feature")))
     bits > 53 && !real && (have_mpc || throw(ArgumentError("libsymengine has to be compiled with MPC for this feature")))
@@ -133,7 +134,11 @@ N(b::BasicType{Val{:Rational}}) = Rational(N(numerator(b)), N(denominator(b))) #
 N(b::BasicType{Val{:RealDouble}}) = convert(Cdouble, b)
 N(b::BasicType{Val{:RealMPFR}}) = convert(BigFloat, b)
 N(b::BasicType{Val{:NaN}}) = NaN
-N(b::BasicType{Val{:Infty}}) = (string(b) == "-inf") ? -Inf : Inf
+function N(b::BasicType{Val{:Infty}})
+    b == oo && return Inf
+    b == -oo && return -Inf
+    b == zoo && return Complex(Inf, Inf)
+end
 
 ## Mapping of SymEngine Constants into julia values
 constant_map = Dict("pi" => π, "eulergamma" => γ, "exp(1)" => e, "catalan" => catalan,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -207,6 +207,8 @@ z,flt, rat, ima, cplx = btypes = [Basic(1), Basic(1.23), Basic(3//5), Basic(2im)
 @test convert(Rational{Int}, rat) == 3//5
 @test convert(Complex{Int}, ima) == 2im
 @test convert(Complex{Int}, cplx) == 1 + 2im
+@test isinf(convert(Float64, oo))
+@test isnan(convert(Float64, NAN))
 
 @test_throws InexactError convert(Int, flt)
 @test_throws InexactError convert(Int, rat)


### PR DESCRIPTION
Currently `evalf` doesn't handle `oo` or `nan` gracefully. This adds a special case for `!isfinite` and expands the conversion of `N`, which was incorrect on `N(-oo)`. Maybe this is better done in `symengine` proper?