### PR TITLE
subs w/o arguments

### DIFF
--- a/src/subs.jl
+++ b/src/subs.jl
@@ -33,7 +33,7 @@ subs(ex::T, d::AbstractDict) where {T<:SymbolicType} = subs(ex, CMapBasicBasic(d
 subs(ex::T, y::Tuple{S, Any}) where {T <: SymbolicType, S<:SymbolicType} = subs(ex, y[1], y[2])
 subs(ex::T, y::Tuple{S, Any}, args...) where {T <: SymbolicType, S<:SymbolicType} = subs(subs(ex, y), args...)
 subs(ex::T, d::Pair...) where {T <: SymbolicType} = subs(ex, [(p.first, p.second) for p in d]...)
-
+subs(ex::SymbolicType) = ex
 
 ## Allow an expression to be called, as with ex(2). When there is more than one symbol, one can rely on order of `free_symbols` or
 ## be explicit by passing in pairs : `ex(x=>1, y=>2)` or a dict `ex(Dict(x=>1, y=>2))`.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -136,6 +136,7 @@ for val in samples
     @test subs(ex, x => val) == val^2 + y^2
     @test subs(ex, SymEngine.CMapBasicBasic(Dict(x=>val))) == val^2 + y^2
     @test subs(ex, Dict(x=>val)) == val^2 + y^2
+    @test subs(ex) == ex
 end
 # This probably results in a number of redundant tests (operator order).
 for val1 in samples, val2 in samples


### PR DESCRIPTION
Close #202 by defining a `subs(ex::SymbolicObject)` method.