### PR TITLE
use isuruf's speedup

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -106,8 +106,25 @@ function get_class_from_id(id::UInt)
     str
 end
 
+# use value of `get_type` to index into a vector storing symbols
+function _get_symengine_classes()
+    d = Vector{Symbol}()
+    i = 0
+    while true
+      s = get_class_from_id(UInt(i))
+      if s == ""
+          break
+    end
+      push!(d, Symbol(s))
+      i+=1
+  end
+    return d
+end
+
+const symengine_classes = _get_symengine_classes()
+
 "Get SymEngine class of an object (e.g. 1=>:Integer, 1//2 =:Rational, sin(x) => :Sin, ..."
-get_symengine_class(s::Basic) = Symbol(get_class_from_id(get_type(s)))
+get_symengine_class(s::Basic) = symengine_classes[get_type(s) + 1]
 
 
 ## Construct symbolic objects
@@ -194,7 +211,7 @@ end
 ## and then
 ## meth(x::BasicType{Val{:Integer}}) = ... or
 ## meth(x::BasicNumber) = ...
-mutable struct BasicType{T} <: Number
+struct BasicType{T} <: Number
     x::Basic
 end
 


### PR DESCRIPTION
Use @isuruf's rewrite of `get_symengine_class` in #285 to reduce memory allocation with `get_symengine_class`

This makes dispatch on `BasicType` nearly as performant as using `ifelse` statements.

A test case (relevant to #279)

```
using SymEngine
using SymEngine: libsymengine, get_symengine_class, is_symbol, Basic, BasicType

adiff(b1::Basic, b2::Basic) = adiff(b1, BasicType(b2))
adiff(b1::Basic, b2::BasicType) =
    throw(ArgumentError("Second argument must be of Symbol type"))

function adiff(b1::Basic, b2::BasicType{Val{:Symbol}})
    a = Basic()
    ret = ccall((:basic_diff, libsymengine), Int, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
    return a
end


function bdiff(b1::Basic, b2::Basic)
    is_symbol(b2) || throw(ArgumentError("Second argument must be of Symbol type"))
    a = Basic()
    ret = ccall((:basic_diff, libsymengine), Int, (Ref{Basic}, Ref{Basic}, Ref{Basic}), a, b1, b2)
    return a
end

@vars x
u = sin(x)
```

```
julia> @time adiff(u,x)
  0.000023 seconds (3 allocations: 48 bytes)

julia> @time bdiff(u,x)
  0.000017 seconds (2 allocations: 32 bytes)
```

Compared to the older `get_symengine_class` we have
```
julia> @time adiff(u, x)
  0.000024 seconds (4 allocations: 72 bytes)
```
