### PR TITLE
add True, False

### DIFF
--- a/src/mathops.jl
+++ b/src/mathops.jl
@@ -90,6 +90,9 @@ for op in [:IM, :PI, :E, :EulerGamma, :Catalan, :GoldenRatio, :oo, :zoo, :NAN]
     eval(Expr(:export, op))
 end
 
+True, False = Basic(C_NULL), Basic(C_NULL);
+export True, False
+
 macro init_constant(op, libnm)
     tup = (Base.Symbol("basic_const_$libnm"), libsymengine)
     alloc_tup = (:basic_new_stack, libsymengine)
@@ -112,14 +115,17 @@ function init_constants()
     @init_constant oo infinity
     @init_constant zoo complex_infinity
     @init_constant NAN nan
+    ccall((:bool_set_true, libsymengine), Nothing, (Ref{Basic},), True)
+    ccall((:bool_set_false, libsymengine), Nothing, (Ref{Basic},), False)
 end
 
-## ## Conversions
+## Conversions
 Base.convert(::Type{Basic}, x::Irrational{:π}) = PI
 Base.convert(::Type{Basic}, x::Irrational{:e}) = E
 Base.convert(::Type{Basic}, x::Irrational{:γ}) = EulerGamma
 Base.convert(::Type{Basic}, x::Irrational{:catalan}) = Catalan
 Base.convert(::Type{Basic}, x::Irrational{:φ}) = (1 + Basic(5)^Basic(1//2))/2
+Base.convert(::Type{Basic}, x::Bool) = x ? True : False
 Base.convert(::Type{BasicType}, x::Irrational) = BasicType(convert(Basic, x))
 
 ## Logical operators

--- a/src/types.jl
+++ b/src/types.jl
@@ -96,6 +96,7 @@ Basic(x::Basic) = x
 Base.promote_rule(::Type{Basic}, ::Type{S}) where {S<:Number} = Basic
 Base.promote_rule(::Type{S}, ::Type{Basic}) where {S<:Number} = Basic
 Base.promote_rule(::Type{S}, ::Type{Basic}) where {S<:AbstractIrrational} = Basic
+Base.promote_rule(::Type{Bool}, ::Type{Basic}) = Basic
 
 ## Class ID
 get_type(s::Basic) = ccall((:basic_get_type, libsymengine), UInt, (Ref{Basic},), s)


### PR DESCRIPTION
In #260 a promote rule for `true` or `false` is setup. Currently this would promote `true` to a symbolic `1` and `false` to a symbolic `0` as `Bool <: Integer`. This provides an alternatative by promoting to a symbolic `True` and symbolic `False`.  

I don't know which is a better choice, this is just meant to provide an option. 

If this option is better, it might be nice to have some means to convert `True` or `False` to 1 or 0 with the `N` function. 